### PR TITLE
fix: return proper error responses for malformed requests (closes #12)

### DIFF
--- a/core/MicroPDProxyServer.py
+++ b/core/MicroPDProxyServer.py
@@ -590,7 +590,19 @@ class Proxy:
 
     async def create_completion(self, raw_request: Request):
         try:
-            request = await raw_request.json()
+            try:
+                request = await raw_request.json()
+            except (json.JSONDecodeError, ValueError):
+                return JSONResponse(
+                    {"error": {"message": "Invalid JSON in request body", "type": "invalid_request_error"}},
+                    status_code=400,
+                )
+
+            if "prompt" not in request:
+                return JSONResponse(
+                    {"error": {"message": "Missing required field: prompt", "type": "invalid_request_error"}},
+                    status_code=400,
+                )
 
             total_length = 0
             prefill_instance = None
@@ -686,14 +698,35 @@ class Proxy:
                     logger.error("[1] Exception in wrapped_generator: %s", str(e))
                     raise
             return StreamingResponse(wrapped_generator(), media_type=media_type)
+        except HTTPException:
+            raise
         except Exception:
-            exc_info = sys.exc_info()
-            print("Error occurred in disagg proxy server")
-            print(exc_info)
+            logger.error("Error in create_completion: %s", sys.exc_info()[1])
+            return JSONResponse(
+                {"error": {"message": "Internal proxy error", "type": "proxy_error"}},
+                status_code=500,
+            )
 
     async def create_chat_completion(self, raw_request: Request):
         try:
-            request = await raw_request.json()
+            try:
+                request = await raw_request.json()
+            except (json.JSONDecodeError, ValueError):
+                return JSONResponse(
+                    {"error": {"message": "Invalid JSON in request body", "type": "invalid_request_error"}},
+                    status_code=400,
+                )
+
+            if "messages" not in request:
+                return JSONResponse(
+                    {"error": {"message": "Missing required field: messages", "type": "invalid_request_error"}},
+                    status_code=400,
+                )
+            if not isinstance(request["messages"], list):
+                return JSONResponse(
+                    {"error": {"message": "Field 'messages' must be a list", "type": "invalid_request_error"}},
+                    status_code=400,
+                )
 
             total_length = 0
             prefill_instance = None
@@ -796,13 +829,14 @@ class Proxy:
                     logger.error("[1] Exception in wrapped_generator: %s", str(e))
                     raise
             return StreamingResponse(wrapped_generator(), media_type=media_type)
+        except HTTPException:
+            raise
         except Exception:
-            exc_info = sys.exc_info()
-            error_messages = [str(e) for e in exc_info if e]
-            print("Error occurred in disagg proxy server")
-            print(error_messages)
-            return StreamingResponse(content=iter(error_messages),
-                                     media_type="application/json")
+            logger.error("Error in create_chat_completion: %s", sys.exc_info()[1])
+            return JSONResponse(
+                {"error": {"message": "Internal proxy error", "type": "proxy_error"}},
+                status_code=500,
+            )
 
     def remove_instance_endpoint(self, instance_type, instance):
         return

--- a/tests/test_large_payload.py
+++ b/tests/test_large_payload.py
@@ -137,3 +137,36 @@ async def test_max_tokens_very_large(client: AsyncClient):
     assert resp.status_code == 200
     data = resp.json()
     assert "choices" in data
+
+
+@pytest.mark.anyio
+async def test_missing_messages_returns_400(client: AsyncClient):
+    """POST /v1/chat/completions without 'messages' should return 400."""
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={"model": "dummy", "max_tokens": 5},
+    )
+    assert resp.status_code == 400
+    assert "messages" in resp.json()["error"]["message"].lower()
+
+
+@pytest.mark.anyio
+async def test_missing_prompt_returns_400(client: AsyncClient):
+    """POST /v1/completions without 'prompt' should return 400."""
+    resp = await client.post(
+        "/v1/completions",
+        json={"model": "dummy", "max_tokens": 5},
+    )
+    assert resp.status_code == 400
+    assert "prompt" in resp.json()["error"]["message"].lower()
+
+
+@pytest.mark.anyio
+async def test_invalid_messages_type_returns_400(client: AsyncClient):
+    """POST /v1/chat/completions with non-list 'messages' should return 400."""
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={"model": "dummy", "messages": "not a list", "max_tokens": 5},
+    )
+    assert resp.status_code == 400
+    assert "list" in resp.json()["error"]["message"].lower()


### PR DESCRIPTION
Fixes #12

## Changes (2 files only)

### core/MicroPDProxyServer.py
- `create_completion`: validate JSON + `prompt` field → 400
- `create_chat_completion`: validate JSON + `messages` field + type check → 400
- Both: `except HTTPException: raise` before generic catch-all
- Both: outer except returns `JSONResponse(500)` not `StreamingResponse(200)` with traceback
- Error details logged server-side only

### tests/test_large_payload.py
- `test_missing_messages_returns_400`
- `test_missing_prompt_returns_400`
- `test_invalid_messages_type_returns_400`

## Error format
```json
{"error": {"message": "...", "type": "invalid_request_error|proxy_error"}}
```