### PR TITLE
fix: resolve CI failures — isort blank line and flaky port allocation

### DIFF
--- a/tests/test_completions_endpoint.py
+++ b/tests/test_completions_endpoint.py
@@ -3,7 +3,6 @@
 import pytest
 from httpx import AsyncClient
 
-
 COMPLETION_PAYLOAD = {
     "model": "dummy",
     "prompt": "Once upon a time",

--- a/tests/test_proxy_matrix.py
+++ b/tests/test_proxy_matrix.py
@@ -43,10 +43,19 @@ MATRIX = [
 ]
 
 
+_used_ports: set[int] = set()
+
+
 def _free_port() -> int:
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
+    """Find a free TCP port, avoiding previously allocated ports."""
+    for _ in range(100):
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = sock.getsockname()[1]
+        if port not in _used_ports:
+            _used_ports.add(port)
+            return port
+    raise RuntimeError("Unable to find a unique free port")
 
 
 def _wait_http_ok(url: str, timeout: float = 40.0) -> None:


### PR DESCRIPTION
## Problem

CI on `main` is red due to two issues:

1. **isort lint failure**: `tests/test_completions_endpoint.py` has an extra blank line between imports and the first constant, violating isort formatting rules.
2. **Flaky test on Python 3.12**: `test_proxy_matrix[1-2-1]` fails intermittently with `[Errno 98] address already in use` because `_free_port()` can return the same port number across multiple calls (classic TOCTOU race — the socket is closed before uvicorn binds to it).

## Fix

1. Remove the extra blank line in `test_completions_endpoint.py`.
2. Track allocated ports in a module-level set in `test_proxy_matrix.py` to prevent duplicate assignments across calls to `_free_port()`.

Both fixes are minimal and test-only — no changes to core logic.