### PR TITLE
docs: add BOT_POLICY.md — rules for automated review and authoring bots

### DIFF
--- a/BOT_POLICY.md
+++ b/BOT_POLICY.md
@@ -1,0 +1,156 @@
+# BOT_POLICY.md — Automated Bot Rules
+
+This file defines the rules that automated bots (CI review bots, cron-driven
+agents, etc.) **must** follow when operating on this repository. Human
+contributors should refer to `CONTRIBUTING.md`.
+
+---
+
+## When Acting as Reviewer
+
+### Identity
+
+Two review bots operate on this repo:
+
+- **hlin99-Review-Bot** — first reviewer
+- **hlin99-Review-BotX** — second reviewer
+
+Each bot uses its own dedicated token. **Never use the author's (hlin99)
+token for reviews.** The author's token is for authoring PRs only.
+
+### What to Review
+
+1. **Skip draft PRs** — do not review, comment, or interact with them.
+2. **Skip already-reviewed commits** — if the PR head SHA has not changed since
+   your last review, do not submit a duplicate review.
+3. **One review per PR per commit SHA** — never submit multiple reviews for the
+   same commit.
+
+### Review Standard
+
+Reviews must be performed to the **strictest standard**. Every line of changed
+code must be examined. Do not approve unless you are confident the code is
+correct.
+
+### Review Checklist
+
+For each non-draft PR with a new commit:
+
+| Area | Check |
+|---|---|
+| **CI** | All checks must be `completed` + `success`. If any check is pending or failed, submit `COMMENT` (not Approve). |
+| **Merge conflicts** | If `mergeable == false`, submit `REQUEST_CHANGES`. |
+| **`core/` changes** | Business logic and API signatures must remain intact. Topology matrix configs `(1,2,1) (2,2,1) (1,2,2) (1,2,4) (1,2,8) (2,2,2) (2,4,1) (2,4,2)` must not be broken. |
+| **Logic errors** | Incorrect conditions, off-by-one, unhandled edge cases. |
+| **Type safety** | Mismatched parameter/return types, missing `None` checks. |
+| **Concurrency** | Race conditions, missing locks, shared mutable state. |
+| **Exception handling** | Bare `except`, swallowed exceptions, resource leaks. |
+| **Security** | Injection risks, hardcoded secrets, unsanitized input. |
+| **Code style** | Unused imports, shadowed variables, unclear naming. |
+| **Test coverage** | New logic must have corresponding tests. |
+
+### Review Verdicts
+
+- **`APPROVE`** — only if the code is correct, CI is fully green, and no issues
+  are found.
+- **`REQUEST_CHANGES`** — if any issue is found. Use inline comments to point
+  to specific files and lines. The PR remains blocked until the author addresses
+  all requested changes and pushes a new commit. Only then should the bot
+  re-review and potentially approve.
+- **`COMMENT`** — if CI is still running or you need to note something without
+  blocking.
+
+### Merge Policy
+
+> **Bots must NEVER merge a PR.** All merge operations are performed manually
+> by a human maintainer.
+
+This is non-negotiable. Do not call the merge API under any circumstances.
+
+### Review Trigger Schedule
+
+- **Has open (non-draft) PRs**: check every **5 minutes** for new commits and
+  review comments.
+- **No open PRs** (all draft or none): check every **15 minutes** to see if
+  any draft PR has been marked ready for review or a new PR has been opened.
+- When a new PR or new commit is detected, reset to the **5-minute** interval.
+- A review can also be triggered immediately via chat command.
+
+### Rate Limiting
+
+- Respect GitHub API rate limits; back off on `429` responses.
+- Do not flood PRs with duplicate comments or reviews.
+
+---
+
+## When Acting as Author (Opening PRs)
+
+### Identity
+
+Bot-authored PRs use the **hlin99** token (the repo owner account).
+
+### Branch Rules
+
+- **Never push directly to `main`.** All changes go through a PR.
+- Branch from the latest `main` and **rebase** (not merge) before opening the
+  PR.
+- **Each PR must be independent** — based on the latest `main`, with no
+  dependencies between PRs. Do not stack PRs or branch off other feature
+  branches.
+- Use descriptive branch names: `fix/issue-12-error-handling`,
+  `feat/add-metrics`, `test/concurrent-edge-cases`.
+
+### Before Pushing
+
+1. **Run pre-commit hooks** — the repo uses pre-commit; run
+   `pre-commit run --all-files`.
+2. **Run the full test suite** — `python -m pytest tests/ -v`.
+3. **Run linters** — `ruff check .` and `isort --check-only --skip core .`.
+4. All three must pass locally before pushing.
+
+### Commit Messages
+
+Follow conventional commits:
+
+```
+<type>: <short description>
+
+[optional body]
+[optional footer]
+```
+
+Types: `fix`, `feat`, `test`, `docs`, `refactor`, `chore`, `ci`.
+
+### PR Description
+
+- Clearly state **what** changed and **why**.
+- Reference related issues (e.g. `closes #12`).
+- If modifying `core/`, explicitly call it out and explain the necessity.
+
+### Responding to Reviews
+
+- Address all `REQUEST_CHANGES` feedback before requesting re-review.
+- Do not force-push over reviewed commits without notifying the reviewer.
+- Keep PRs focused — one concern per PR.
+
+### Active PR Maintenance
+
+When the bot has open (non-draft) PRs with `CHANGES_REQUESTED` reviews:
+
+- **Every 5 minutes**, check for new review comments on open PRs.
+- Read and address each comment: fix the code, push a new commit.
+- After pushing the fix, **re-request review** from the reviewer(s) who
+  requested changes (via the GitHub API `POST
+  /repos/{owner}/{repo}/pulls/{number}/requested_reviewers`).
+- Continue this cycle until the PR is approved or closed.
+
+---
+
+## General
+
+- **Secrets** — never hardcode tokens or credentials in code, PR descriptions,
+  or bot prompts. Read from secure storage at runtime.
+- **Scope** — bots should limit their actions to reviewing code. No issue
+  triage, no label management, no branch deletion unless explicitly configured.
+- **Transparency** — every bot action should produce a brief summary of what it
+  did (or chose not to do) for audit purposes.


### PR DESCRIPTION
## What

Adds `BOT_POLICY.md` to define the rules automated bots must follow when operating on this repo.

## Why

We had incidents where review bots auto-merged PRs that still had `CHANGES_REQUESTED` reviews and failing CI. This file establishes clear guardrails.

## Key Rules

**As Reviewer:**
- Skip draft PRs and already-reviewed commits
- Only `APPROVE` when CI is fully green and code is correct
- **Never merge** — all merges are manual by a human
- One review per PR per commit SHA (no spam)

**As Author:**
- Never push to `main` directly, always PR
- Rebase before pushing (no merge commits)
- Run pre-commit + tests + linters locally before pushing
- Conventional commit messages

**General:**
- No hardcoded secrets
- Bots only review code, no other repo management