### PR TITLE
feat: topology expansion in YAML config + log_level (Task 7)

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -20,6 +20,8 @@ from typing import Any, Dict, List, Optional
 import yaml
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
+from topology import expand_topology
+
 
 class ProxyConfig(BaseModel):
     """Validated proxy configuration."""
@@ -30,6 +32,7 @@ class ProxyConfig(BaseModel):
     prefill: List[str] = []
     decode: List[str]
     port: int = 8000
+    log_level: str = "warning"
     generator_on_p_node: bool = False
     roundrobin: bool = False
     admin_api_key: Optional[str] = None
@@ -44,6 +47,16 @@ class ProxyConfig(BaseModel):
     def _port_in_range(cls, v: int) -> int:
         if not (1 <= v <= 65535):
             raise ValueError(f"port must be between 1 and 65535, got {v}")
+        return v
+
+    @field_validator("log_level")
+    @classmethod
+    def _valid_log_level(cls, v: str) -> str:
+        valid = {"debug", "info", "warning", "error"}
+        if v not in valid:
+            raise ValueError(
+                f"log_level must be one of {sorted(valid)}, got {v!r}"
+            )
         return v
 
     @field_validator("prefill", "decode", mode="before")
@@ -114,6 +127,44 @@ class ProxyConfig(BaseModel):
         return data
 
     # ------------------------------------------------------------------
+    # Topology expansion helper
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _expand_node_config(role: str, node_cfg: Any) -> List[str]:
+        """Expand a YAML node config into a flat list of host:port strings.
+
+        Accepts either:
+        - A list of strings (backward compat): ``["10.0.0.1:8000"]``
+        - A topology dict: ``{nodes: [...], tp_size: N, dp_size: M, ...}``
+        """
+        if isinstance(node_cfg, list):
+            return node_cfg
+        if isinstance(node_cfg, dict):
+            required = {"nodes", "tp_size", "dp_size", "world_size_per_node"}
+            missing = required - set(node_cfg.keys())
+            if missing:
+                raise ValueError(
+                    f"{role} topology config missing keys: {sorted(missing)}"
+                )
+            unknown = set(node_cfg.keys()) - required
+            if unknown:
+                raise ValueError(
+                    f"{role} topology config has unknown keys: {sorted(unknown)}"
+                )
+            return expand_topology(
+                role=role,
+                nodes=node_cfg["nodes"],
+                tp_size=node_cfg["tp_size"],
+                dp_size=node_cfg["dp_size"],
+                world_size_per_node=node_cfg["world_size_per_node"],
+            )
+        raise ValueError(
+            f"{role} must be a list of addresses or a topology dict, "
+            f"got {type(node_cfg).__name__}"
+        )
+
+    # ------------------------------------------------------------------
     # Construction helpers
     # ------------------------------------------------------------------
 
@@ -132,6 +183,7 @@ class ProxyConfig(BaseModel):
             "port": 8000,
             "generator_on_p_node": False,
             "roundrobin": False,
+            "log_level": "warning",
         }
 
         # 1. Load YAML base (if provided)
@@ -139,6 +191,14 @@ class ProxyConfig(BaseModel):
         config_path = getattr(args, "config", None)
         if config_path:
             yaml_data = cls.load_yaml(config_path)
+
+        # 1b. Expand topology-style prefill/decode configs into flat lists
+        for role in ("prefill", "decode"):
+            if role in yaml_data and not isinstance(yaml_data[role], list):
+                yaml_data[role] = cls._expand_node_config(role, yaml_data[role])
+            elif role in yaml_data and isinstance(yaml_data[role], list):
+                # Could be a list of strings (backward compat) — keep as-is
+                yaml_data[role] = cls._expand_node_config(role, yaml_data[role])
 
         # 2. Build merged dict: YAML first, then CLI overrides.
         #    NOTE: argparse cannot distinguish "user explicitly passed the

--- a/core/topology.py
+++ b/core/topology.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Topology expansion: convert node + TP/DP parameters into instance endpoints.
+
+Mirrors the logic in ``xpyd_start_proxy.sh:build_instance_endpoints``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def _is_power_of_two(n: int) -> bool:
+    return n > 0 and (n & (n - 1)) == 0
+
+
+def validate_topology(
+    role: str,
+    nodes: List[str],
+    tp_size: int,
+    dp_size: int,
+    world_size_per_node: int,
+) -> None:
+    """Validate topology parameters. Raises ``ValueError`` on failure."""
+    if tp_size < 1:
+        raise ValueError(f"{role} tp_size must be a positive integer")
+    if dp_size < 1:
+        raise ValueError(f"{role} dp_size must be a positive integer")
+    if world_size_per_node < 1:
+        raise ValueError(f"{role} world_size_per_node must be a positive integer")
+    if not _is_power_of_two(tp_size):
+        raise ValueError(f"{role} tp_size must be a power of two, got {tp_size}")
+    if not _is_power_of_two(dp_size):
+        raise ValueError(f"{role} dp_size must be a power of two, got {dp_size}")
+    if tp_size * dp_size != len(nodes) * world_size_per_node:
+        raise ValueError(
+            f"{role} topology invalid: tp_size({tp_size}) * dp_size({dp_size}) "
+            f"!= nodes({len(nodes)}) * world_size_per_node({world_size_per_node})"
+        )
+
+
+def expand_topology(
+    role: str,
+    nodes: List[str],
+    tp_size: int,
+    dp_size: int,
+    world_size_per_node: int,
+) -> List[str]:
+    """Expand topology into a list of ``host:port`` instance endpoints.
+
+    Each node entry is ``"ip:base_port"``.  Returns one endpoint per DP
+    instance, following the same mapping as ``xpyd_start_proxy.sh``.
+    """
+    validate_topology(role, nodes, tp_size, dp_size, world_size_per_node)
+
+    # Parse node entries into (ip, base_port) pairs
+    parsed: List[tuple] = []
+    for entry in nodes:
+        parts = entry.rsplit(":", 1)
+        if len(parts) != 2:
+            raise ValueError(f"{role} invalid node format: {entry}")
+        ip, port_str = parts
+        try:
+            base_port = int(port_str)
+        except ValueError as exc:
+            raise ValueError(
+                f"{role} invalid port in node {entry}: {exc}"
+            ) from exc
+        parsed.append((ip, base_port))
+
+    node_instance_counts: Dict[int, int] = {}
+    endpoints: List[str] = []
+
+    for instance_index in range(dp_size):
+        start_rank = instance_index * tp_size
+        main_node = start_rank // world_size_per_node
+
+        if main_node >= len(nodes):
+            raise ValueError(
+                f"{role} topology expansion failed: computed node index "
+                f"{main_node} out of range (only {len(nodes)} nodes)"
+            )
+
+        local_index = node_instance_counts.get(main_node, 0)
+        ip, base_port = parsed[main_node]
+        port = base_port + local_index
+        node_instance_counts[main_node] = local_index + 1
+        endpoints.append(f"{ip}:{port}")
+
+    return endpoints

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1,0 +1,241 @@
+"""Tests for topology expansion and topology-style YAML config."""
+
+from __future__ import annotations
+
+import argparse
+import textwrap
+from pathlib import Path
+
+import pytest
+from config import ProxyConfig
+from topology import expand_topology, validate_topology
+
+# ------------------------------------------------------------------
+# topology.py unit tests
+# ------------------------------------------------------------------
+
+
+class TestValidateTopology:
+    def test_valid(self):
+        validate_topology("prefill", ["10.0.0.1:8100"], 8, 1, 8)
+
+    def test_tp_not_power_of_two(self):
+        with pytest.raises(ValueError, match="power of two"):
+            validate_topology("prefill", ["10.0.0.1:8100"], 3, 1, 3)
+
+    def test_dp_not_power_of_two(self):
+        with pytest.raises(ValueError, match="power of two"):
+            validate_topology("decode", ["10.0.0.1:8200"], 1, 3, 3)
+
+    def test_product_mismatch(self):
+        with pytest.raises(ValueError, match="topology invalid"):
+            validate_topology("prefill", ["10.0.0.1:8100"], 8, 2, 8)
+
+    def test_negative_tp(self):
+        with pytest.raises(ValueError, match="positive integer"):
+            validate_topology("prefill", ["10.0.0.1:8100"], -1, 1, 1)
+
+
+class TestExpandTopology:
+    def test_single_node_single_instance(self):
+        result = expand_topology("prefill", ["10.0.0.1:8100"], 8, 1, 8)
+        assert result == ["10.0.0.1:8100"]
+
+    def test_single_node_multiple_instances(self):
+        result = expand_topology("decode", ["10.0.0.1:8200"], 1, 8, 8)
+        expected = [f"10.0.0.1:{8200 + i}" for i in range(8)]
+        assert result == expected
+
+    def test_two_nodes_dp16(self):
+        result = expand_topology(
+            "decode",
+            ["10.0.0.1:8200", "10.0.0.2:8200"],
+            1,
+            16,
+            8,
+        )
+        assert len(result) == 16
+        # First 8 on node 0
+        for i in range(8):
+            assert result[i] == f"10.0.0.1:{8200 + i}"
+        # Next 8 on node 1
+        for i in range(8):
+            assert result[8 + i] == f"10.0.0.2:{8200 + i}"
+
+    def test_cross_node_tp(self):
+        # 2 nodes, TP16, DP1, world=8 → 1 instance spanning 2 nodes
+        result = expand_topology(
+            "prefill",
+            ["10.0.0.1:8100", "10.0.0.2:8100"],
+            16,
+            1,
+            8,
+        )
+        assert result == ["10.0.0.1:8100"]
+
+    def test_invalid_node_format(self):
+        with pytest.raises(ValueError, match="invalid node format"):
+            expand_topology("prefill", ["badformat"], 1, 1, 1)
+
+
+# ------------------------------------------------------------------
+# YAML topology integration tests
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_yaml(tmp_path):
+    def _write(content: str) -> Path:
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent(content))
+        return p
+
+    return _write
+
+
+def _make_args(**overrides):
+    defaults = {
+        "config": None,
+        "model": None,
+        "prefill": None,
+        "decode": None,
+        "port": 8000,
+        "generator_on_p_node": False,
+        "roundrobin": False,
+        "log_level": "warning",
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestYamlTopologyExpansion:
+    def test_topology_style_yaml(self, tmp_yaml):
+        p = tmp_yaml(
+            """\
+            model: /path/model
+            prefill:
+              nodes:
+                - "10.0.0.1:8100"
+              tp_size: 8
+              dp_size: 1
+              world_size_per_node: 8
+            decode:
+              nodes:
+                - "10.0.0.3:8200"
+                - "10.0.0.4:8200"
+              tp_size: 1
+              dp_size: 16
+              world_size_per_node: 8
+            """
+        )
+        args = _make_args(config=str(p))
+        cfg = ProxyConfig.from_args(args)
+        assert cfg.prefill == ["10.0.0.1:8100"]
+        assert len(cfg.decode) == 16
+        assert cfg.decode[0] == "10.0.0.3:8200"
+        assert cfg.decode[8] == "10.0.0.4:8200"
+
+    def test_flat_list_still_works(self, tmp_yaml):
+        p = tmp_yaml(
+            """\
+            model: /path/model
+            decode:
+              - "10.0.0.1:8000"
+              - "10.0.0.2:8000"
+            """
+        )
+        args = _make_args(config=str(p))
+        cfg = ProxyConfig.from_args(args)
+        assert cfg.decode == ["10.0.0.1:8000", "10.0.0.2:8000"]
+
+    def test_topology_missing_keys(self, tmp_yaml):
+        p = tmp_yaml(
+            """\
+            model: /path/model
+            decode:
+              nodes:
+                - "10.0.0.1:8200"
+              tp_size: 1
+            """
+        )
+        args = _make_args(config=str(p))
+        with pytest.raises(ValueError, match="missing keys"):
+            ProxyConfig.from_args(args)
+
+    def test_topology_invalid_constraint(self, tmp_yaml):
+        p = tmp_yaml(
+            """\
+            model: /path/model
+            decode:
+              nodes:
+                - "10.0.0.1:8200"
+              tp_size: 8
+              dp_size: 2
+              world_size_per_node: 8
+            """
+        )
+        args = _make_args(config=str(p))
+        with pytest.raises(ValueError, match="topology invalid"):
+            ProxyConfig.from_args(args)
+
+    def test_cli_overrides_yaml_topology(self, tmp_yaml):
+        p = tmp_yaml(
+            """\
+            model: /path/model
+            decode:
+              nodes:
+                - "10.0.0.1:8200"
+              tp_size: 1
+              dp_size: 1
+              world_size_per_node: 1
+            """
+        )
+        args = _make_args(
+            config=str(p),
+            decode=["10.0.0.99:9999"],
+        )
+        cfg = ProxyConfig.from_args(args)
+        assert cfg.decode == ["10.0.0.99:9999"]
+
+    def test_log_level_from_yaml(self, tmp_yaml):
+        p = tmp_yaml(
+            """\
+            model: /path/model
+            decode:
+              - "10.0.0.1:8000"
+            log_level: debug
+            """
+        )
+        args = _make_args(config=str(p))
+        cfg = ProxyConfig.from_args(args)
+        assert cfg.log_level == "debug"
+
+    def test_invalid_log_level(self, tmp_yaml):
+        p = tmp_yaml(
+            """\
+            model: /path/model
+            decode:
+              - "10.0.0.1:8000"
+            log_level: verbose
+            """
+        )
+        args = _make_args(config=str(p))
+        with pytest.raises(ValueError, match="log_level"):
+            ProxyConfig.from_args(args)
+
+    def test_topology_unknown_keys_rejected(self, tmp_yaml):
+        p = tmp_yaml(
+            """\
+            model: /path/model
+            decode:
+              nodes:
+                - "10.0.0.1:8200"
+              tp_size: 1
+              dp_size: 1
+              world_size_per_node: 1
+              extra_key: bad
+            """
+        )
+        args = _make_args(config=str(p))
+        with pytest.raises(ValueError, match="unknown keys"):
+            ProxyConfig.from_args(args)


### PR DESCRIPTION
## Task 7 continuation: Topology-style YAML config

PR #60 added basic YAML config support. This PR adds the topology expansion feature per the updated Task 7 spec.

### Changes
- New `core/topology.py`: `validate_topology()` and `expand_topology()`
  - Mirrors `xpyd_start_proxy.sh` build_instance_endpoints logic in Python
  - Validates: tp/dp powers of two, product constraint
- YAML `prefill`/`decode` now supports topology dict format:
  ```yaml
  decode:
    nodes:
      - "10.0.0.3:8200"
      - "10.0.0.4:8200"
    tp_size: 1
    dp_size: 16
    world_size_per_node: 8
  ```
  Expands into 16 flat `host:port` addresses automatically
- Backward compatible: flat list format still works
- Add `log_level` field (debug|info|warning|error, default: warning)
- Unknown keys in topology dict rejected

### Tests
- 18 new tests: topology validation, expansion, YAML integration
- All 141 existing tests pass

### Validation
- pre-commit: all pass
- ruff check: all pass
- pytest: 141 passed, 1 skipped, 0 failed