### PR TITLE
ci: improve build job — wheel build, install, smoke test, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,5 +80,5 @@ jobs:
       - name: Run tests (installed mode)
         run: |
           pip install pytest pytest-asyncio aiohttp requests
-          PYTHONPATH="${PYTHONPATH}:${GITHUB_WORKSPACE}/dummy_nodes" \
+          PYTHONPATH="${PYTHONPATH}:${GITHUB_WORKSPACE}/core:${GITHUB_WORKSPACE}/dummy_nodes" \
             python -m pytest tests/test_cli_and_discovery.py -v --tb=short


### PR DESCRIPTION
## Changes

Improve the CI `build` job to be more thorough:

- **Build wheel + sdist** via `python -m build` (instead of `pip install .`)
- **Install from built wheel** — validates the actual distribution artifact
- **CLI smoke test** — `pdproxy --help` and `pdproxy --version`
- **Run CLI/discovery tests** in installed mode

This ensures the packaging pipeline produces a working wheel and the installed CLI behaves correctly.