### PR TITLE
docs: rename node to instance in tasklist Task 9a spec

### DIFF
--- a/tasklist_openclaw.md
+++ b/tasklist_openclaw.md
@@ -228,31 +228,31 @@ Make the proxy self-healing: detect failing nodes, stop sending them traffic, re
 
 #### 9a: Instance Registry
 
-**What:** A centralized `InstanceRegistry` that tracks every prefill/decode node's state in one place. All other components (scheduler, circuit breaker, health monitor) read from and write to the registry.
+**What:** A centralized `InstanceRegistry` that tracks every prefill/decode instance's state in one place. All other components (scheduler, circuit breaker, health monitor) read from and write to the registry.
 
-**Why:** Currently node state is scattered across `prefill_instances`, `decode_instances`, cyclers, and the scheduler's internal counters. Adding/removing a node requires touching multiple places. A single registry makes state management reliable.
+**Why:** Currently instance state is scattered across `prefill_instances`, `decode_instances`, cyclers, and the scheduler's internal counters. Adding/removing an instance requires touching multiple places. A single registry makes state management reliable.
 
 **Implementation:**
-- `InstanceRegistry` stores per-node: `address`, `role` (prefill/decode), `status` (healthy/unhealthy/unknown), `circuit_breaker_state`, `last_health_check`, `active_request_count`
-- `get_available_nodes(role)` → returns only healthy nodes with closed circuit breakers
+- `InstanceRegistry` stores per-instance: `address`, `role` (prefill/decode), `status` (healthy/unhealthy/unknown), `circuit_breaker_state`, `last_health_check`, `active_request_count`
+- `get_available_instances(role)` → returns only healthy instances with closed circuit breakers
 - `mark_healthy(addr)` / `mark_unhealthy(addr)` — called by health monitor
 - `record_success(addr)` / `record_failure(addr)` — called after each request, feeds circuit breaker
 - Scheduler reads from registry instead of raw instance lists
 
 **Verification:**
 ```
-# Start with 4 decode nodes
-registry.get_available_nodes("decode")
+# Start with 4 decode instances
+registry.get_available_instances("decode")
 → ["10.0.0.1:8200", "10.0.0.2:8200", "10.0.0.3:8200", "10.0.0.4:8200"]
 
-# Node 2 marked unhealthy
+# Instance 2 marked unhealthy
 registry.mark_unhealthy("10.0.0.2:8200")
-registry.get_available_nodes("decode")
+registry.get_available_instances("decode")
 → ["10.0.0.1:8200", "10.0.0.3:8200", "10.0.0.4:8200"]
 
-# Node 2 recovers
+# Instance 2 recovers
 registry.mark_healthy("10.0.0.2:8200")
-registry.get_available_nodes("decode")
+registry.get_available_instances("decode")
 → ["10.0.0.1:8200", "10.0.0.2:8200", "10.0.0.3:8200", "10.0.0.4:8200"]
 ```
 
@@ -384,33 +384,33 @@ retry:
 
 #### 9d: Health Monitor
 
-**What:** Background task that continuously pings every node and updates the Instance Registry, which in turn drives circuit breaker state transitions.
+**What:** Background task that continuously pings every instance and updates the Instance Registry, which in turn drives circuit breaker state transitions.
 
-**Why:** Without active health checking, we only discover a node is dead when a real user request fails. With health monitoring, dead nodes are detected proactively (within 10 seconds) and removed from rotation before any user is affected.
+**Why:** Without active health checking, we only discover an instance is dead when a real user request fails. With health monitoring, dead instances are detected proactively (within 10 seconds) and removed from rotation before any user is affected.
 
 **How it works:**
 ```
 Every 10 seconds:
-  For each node in registry:
-    GET http://{node}/health (timeout: 3s)
+  For each instance in registry:
+    GET http://{instance}/health (timeout: 3s)
     If 200 OK:
-      registry.mark_healthy(node)
+      registry.mark_healthy(instance)
       → If circuit was OPEN and timeout expired: transition to HALF-OPEN
     If timeout/error:
-      registry.mark_unhealthy(node)
+      registry.mark_unhealthy(instance)
       → Feeds into circuit breaker failure count
 ```
 
 **Example scenario:**
 ```
-t=0s    All 4 decode nodes healthy
-t=10s   Health check: node 2 timeout → mark unhealthy (failure count: 1)
-t=20s   Health check: node 2 timeout → mark unhealthy (failure count: 2)
+t=0s    All 4 decode instances healthy
+t=10s   Health check: instance 2 timeout → mark unhealthy (failure count: 1)
+t=20s   Health check: instance 2 timeout → mark unhealthy (failure count: 2)
 ...
-t=50s   Health check: node 2 timeout → failure count reaches 5
-        → Circuit breaker OPENS for node 2
+t=50s   Health check: instance 2 timeout → failure count reaches 5
+        → Circuit breaker OPENS for instance 2
         → Log: "[HEALTH] 10.0.0.2:8200 circuit OPEN after 5 failures"
-t=60s   Node 2 comes back, health check returns 200
+t=60s   Instance 2 comes back, health check returns 200
         → mark healthy, circuit → HALF-OPEN → probe succeeds → CLOSED
         → Log: "[HEALTH] 10.0.0.2:8200 recovered, circuit CLOSED"
 ```
@@ -444,7 +444,7 @@ health_check:
 - All new features default to **disabled** for backward compatibility
 - Must not break existing topology matrix tests
 - Circuit breaker, retry, and health check are independent — each can be enabled separately
-- Startup node discovery from Task 8 should integrate with the Instance Registry
+- Startup instance discovery from Task 8 should integrate with the Instance Registry
 
 ### CI Testing Strategy
 


### PR DESCRIPTION
Rename `node` to `instance` in Task 9a (Instance Registry) and 9d (Health Monitor) sections of `tasklist_openclaw.md` for naming consistency.

Changes:
- `get_available_nodes(role)` → `get_available_instances(role)`
- Per-node descriptions → per-instance in 9a and 9d
- Code examples and scenario text updated
- Constraints: startup node discovery → startup instance discovery
- Only Task 9a and 9d sections modified; other tasks untouched
- Generic references like "backend nodes" left unchanged