### PR TITLE
refactor: import CircuitBreakerState from circuit_breaker module

### DIFF
--- a/core/registry.py
+++ b/core/registry.py
@@ -22,12 +22,17 @@ class InstanceStatus(str, Enum):
     UNKNOWN = "unknown"
 
 
-class CircuitBreakerState(str, Enum):
-    """Circuit breaker state machine states."""
+try:
+    from circuit_breaker import CircuitBreakerState
+except ImportError:
+    import enum
 
-    CLOSED = "closed"
-    OPEN = "open"
-    HALF_OPEN = "half_open"
+    class CircuitBreakerState(str, enum.Enum):  # type: ignore[no-redef]
+        """Circuit breaker state machine states."""
+
+        CLOSED = "closed"
+        OPEN = "open"
+        HALF_OPEN = "half_open"
 
 
 @dataclass


### PR DESCRIPTION
## Summary

`CircuitBreakerState` conceptually belongs to the circuit breaker module, not the registry. This PR imports it from `circuit_breaker` when available, with a local fallback for backward compatibility until `circuit_breaker.py` is merged (PR #76).

## Changes

- Replace the inline `CircuitBreakerState` enum in `core/registry.py` with a `try/except` import from `circuit_breaker`
- Local fallback definition preserved so existing code works before PR #76 merges

## Testing

- All 26 tests in `test_instance_registry.py` pass
- pre-commit, ruff, and flake8 all clean