### PR TITLE
docs: replace per-node with per-instance in resilience docs

### DIFF
--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -6,8 +6,8 @@
 ## Overview
 
 MicroPDProxy's resilience layer consists of four components that work together
-to detect failures, isolate bad nodes, retry failed requests, and
-automatically recover when nodes come back online.
+to detect failures, isolate bad instances, retry failed requests, and
+automatically recover when instances come back online.
 
 ```
                     ┌──────────────────┐
@@ -16,55 +16,56 @@ automatically recover when nodes come back online.
                     └────────┬─────────┘
                              │ mark healthy / unhealthy
                              ▼
-┌──────────┐        ┌──────────────────┐        ┌─────────────────┐
-│ Incoming │───────►│ Instance Registry │───────►│ Circuit Breaker │
-│ Request  │        │  (node state DB)  │        │  (per-node FSM) │
-└──────────┘        └──────────────────┘        └────────┬────────┘
-                                                         │ node available?
-                                                         ▼
-                                                ┌─────────────────┐
-                                                │     Retry       │
-                                                │ (exp. backoff)  │
-                                                └─────────────────┘
+┌──────────┐        ┌──────────────────────┐        ┌─────────────────────┐
+│ Incoming │───────►│  Instance Registry    │───────►│   Circuit Breaker   │
+│ Request  │        │ (instance state DB)   │        │ (per-instance FSM)  │
+└──────────┘        └──────────────────────┘        └────────┬────────────┘
+                                                             │ instance available?
+                                                             ▼
+                                                    ┌─────────────────┐
+                                                    │     Retry       │
+                                                    │ (exp. backoff)  │
+                                                    └─────────────────┘
 ```
 
-**Flow:** The Health Monitor continuously probes nodes and updates the Instance
-Registry. When a request arrives, the scheduler queries the registry for
-available nodes (those that are healthy and have a closed circuit breaker). If
-a request fails, the Retry component re-dispatches it to a different healthy
-node with exponential backoff. Repeated failures trigger the Circuit Breaker to
-open, removing the node from rotation until it recovers.
+**Flow:** The Health Monitor continuously probes instances and updates the
+Instance Registry. When a request arrives, the scheduler queries the registry
+for available instances (those that are healthy and have a closed circuit
+breaker). If a request fails, the Retry component re-dispatches it to a
+different healthy instance with exponential backoff. Repeated failures trigger
+the Circuit Breaker to open, removing the instance from rotation until it
+recovers.
 
 ## Instance Registry
 
 ### What
 
-A centralized `InstanceRegistry` that tracks every prefill and decode node's
-state in one place. All other components — scheduler, circuit breaker, health
-monitor — read from and write to the registry.
+A centralized `InstanceRegistry` that tracks every prefill and decode
+instance's state in one place. All other components — scheduler, circuit
+breaker, health monitor — read from and write to the registry.
 
 ### Why
 
-Currently node state is scattered across multiple data structures. Adding or
-removing a node requires touching several places. A single registry makes
-state management reliable and consistent.
+Currently instance state is scattered across multiple data structures. Adding
+or removing an instance requires touching several places. A single registry
+makes state management reliable and consistent.
 
 ### API
 
 | Method | Description |
 |---|---|
-| `add(role, address)` | Register a node (prefill or decode). |
-| `remove(address)` | Remove a node from the registry. |
-| `get_available_nodes(role)` | Return only healthy nodes with closed circuit breakers. |
-| `mark_healthy(address)` | Mark a node as healthy (called by Health Monitor). |
-| `mark_unhealthy(address)` | Mark a node as unhealthy (called by Health Monitor). |
+| `add(role, address)` | Register an instance (prefill or decode). |
+| `remove(address)` | Remove an instance from the registry. |
+| `get_available_instances(role)` | Return only healthy instances with closed circuit breakers. |
+| `mark_healthy(address)` | Mark an instance as healthy (called by Health Monitor). |
+| `mark_unhealthy(address)` | Mark an instance as unhealthy (called by Health Monitor). |
 | `record_success(address)` | Record a successful request (feeds circuit breaker). |
 | `record_failure(address)` | Record a failed request (feeds circuit breaker). |
 | `get_status(address)` | Return current status, circuit state, and metadata. |
 
-### Per-Node State
+### Per-Instance State
 
-Each node entry stores: `address`, `role` (prefill/decode), `status`
+Each instance entry stores: `address`, `role` (prefill/decode), `status`
 (healthy/unhealthy/unknown), `circuit_breaker_state`, `last_health_check`,
 `active_request_count`.
 
@@ -72,36 +73,36 @@ Each node entry stores: `address`, `role` (prefill/decode), `status`
 
 ### What
 
-A background async task that continuously pings every registered node and
+A background async task that continuously pings every registered instance and
 updates the Instance Registry based on health check responses.
 
 ### Why
 
-Without active health checking, dead nodes are only discovered when a real
+Without active health checking, dead instances are only discovered when a real
 user request fails. The Health Monitor detects failures proactively — typically
-within one check interval — and removes bad nodes from rotation before users
-are affected.
+within one check interval — and removes bad instances from rotation before
+users are affected.
 
 ### How It Works
 
 ```
 Every <interval_seconds> seconds:
-  For each node in registry:
-    GET http://{node}/health  (timeout: <timeout_seconds>)
-    If 200 OK  → registry.mark_healthy(node)
-    If error   → registry.mark_unhealthy(node)
+  For each instance in registry:
+    GET http://{instance}/health  (timeout: <timeout_seconds>)
+    If 200 OK  → registry.mark_healthy(instance)
+    If error   → registry.mark_unhealthy(instance)
 ```
 
 ### Example Timeline
 
 ```
-t=0s    All 4 decode nodes healthy
-t=10s   Health check: node 2 timeout → mark unhealthy (failure count: 1)
-t=20s   Health check: node 2 timeout → failure count: 2
+t=0s    All 4 decode instances healthy
+t=10s   Health check: instance 2 timeout → mark unhealthy (failure count: 1)
+t=20s   Health check: instance 2 timeout → failure count: 2
 ...
-t=50s   Health check: node 2 timeout → failure count reaches threshold
-        → Circuit breaker OPENS for node 2
-t=60s   Node 2 comes back, health check returns 200
+t=50s   Health check: instance 2 timeout → failure count reaches threshold
+        → Circuit breaker OPENS for instance 2
+t=60s   Instance 2 comes back, health check returns 200
         → mark healthy → circuit transitions to HALF-OPEN → probe → CLOSED
 ```
 
@@ -118,15 +119,15 @@ health_check:
 
 ### What
 
-A per-node finite state machine that automatically stops sending requests to a
-node that is consistently failing, and gradually recovers when the node comes
-back.
+A per-instance finite state machine that automatically stops sending requests
+to an instance that is consistently failing, and gradually recovers when the
+instance comes back.
 
 ### Why
 
-Without a circuit breaker, a dead node keeps receiving requests that all fail,
-wasting time and causing user-visible errors. With it, failures are detected
-quickly and traffic is transparently redirected to healthy nodes.
+Without a circuit breaker, a dead instance keeps receiving requests that all
+fail, wasting time and causing user-visible errors. With it, failures are
+detected quickly and traffic is transparently redirected to healthy instances.
 
 ### State Machine
 
@@ -158,15 +159,15 @@ quickly and traffic is transparently redirected to healthy nodes.
 ### Example Scenario Timeline
 
 ```
-t=0s    Node 10.0.0.2:8200 starts failing
+t=0s    Instance 10.0.0.2:8200 starts failing
 t=0-5s  5 consecutive request failures (failure_threshold=5)
-        → Circuit OPENS for this node
-t=5-35s All requests skip this node (routed to healthy nodes)
+        → Circuit OPENS for this instance
+t=5-35s All requests skip this instance (routed to healthy instances)
         → Users see no errors (transparent failover)
 t=35s   timeout_duration=30s expires → Circuit goes HALF-OPEN
 t=35s   One probe request sent to 10.0.0.2:8200
         → If success: send 1 more (success_threshold=2)
-        → If both succeed: Circuit CLOSES, node is back in rotation
+        → If both succeed: Circuit CLOSES, instance is back in rotation
         → If probe fails: Circuit re-OPENS, wait another 30s
 ```
 
@@ -183,11 +184,11 @@ circuit_breaker:
 
 ### Status Endpoint
 
-When enabled, `GET /status` includes per-node circuit breaker state:
+When enabled, `GET /status` includes per-instance circuit breaker state:
 
 ```json
 {
-  "nodes": {
+  "instances": {
     "10.0.0.1:8200": {"status": "healthy", "circuit": "closed"},
     "10.0.0.2:8200": {"status": "unhealthy", "circuit": "open", "open_since": "2026-04-01T10:00:05Z"},
     "10.0.0.3:8200": {"status": "healthy", "circuit": "closed"}
@@ -199,15 +200,15 @@ When enabled, `GET /status` includes per-node circuit breaker state:
 
 ### What
 
-When a request to a node fails with a retryable error, the proxy automatically
-retries on a *different* healthy node, with increasing delay between attempts
-to avoid overwhelming the system.
+When a request to an instance fails with a retryable error, the proxy
+automatically retries on a *different* healthy instance, with increasing delay
+between attempts to avoid overwhelming the system.
 
 ### Why
 
 Transient failures (network blips, brief overloads) can be recovered from
 without the user ever seeing an error. Backoff with jitter prevents all retries
-from hitting the same node at the same time (thundering herd problem).
+from hitting the same instance at the same time (thundering herd problem).
 
 ### Backoff Formula
 
@@ -234,7 +235,7 @@ Without retry:
 |---|---|
 | 408 Request Timeout | 4xx client errors (400, 401, 403, 404, 422) |
 | 429 Too Many Requests | Requests that already started streaming |
-| 500 Internal Server Error | When all nodes have open circuit breakers |
+| 500 Internal Server Error | When all instances have open circuit breakers |
 | 502 Bad Gateway | |
 | 503 Service Unavailable | |
 | 504 Gateway Timeout | |
@@ -298,10 +299,10 @@ enabled independently.
 
 | Symptom | Possible Cause | Resolution |
 |---|---|---|
-| All requests return 503 | All nodes are unhealthy or all circuit breakers are open | Check node health manually; verify network connectivity; check `/status` endpoint for circuit breaker states |
-| Node marked unhealthy but is actually running | Health check timeout too short; network latency | Increase `health_check.timeout_seconds` |
+| All requests return 503 | All instances are unhealthy or all circuit breakers are open | Check instance health manually; verify network connectivity; check `/status` endpoint for circuit breaker states |
+| Instance marked unhealthy but is actually running | Health check timeout too short; network latency | Increase `health_check.timeout_seconds` |
 | Circuit breaker opens too quickly | `failure_threshold` is too low or transient errors are common | Increase `failure_threshold` or `window_duration_seconds` |
-| Circuit breaker never recovers | Node is genuinely down; `timeout_duration_seconds` is too long | Check node status; reduce `timeout_duration_seconds` for faster probing |
+| Circuit breaker never recovers | Instance is genuinely down; `timeout_duration_seconds` is too long | Check instance status; reduce `timeout_duration_seconds` for faster probing |
 | Retries cause duplicate processing | Retrying non-idempotent requests | Ensure only idempotent endpoints are exposed through the proxy; streaming requests are never retried |
 | Retry storms under load | Too many retries with insufficient backoff | Reduce `max_retries`; increase `initial_backoff_ms` and `backoff_multiplier` |
 | High latency on retried requests | Backoff delays accumulating | Reduce `max_backoff_ms`; consider whether retries are appropriate for your latency SLA |

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -3,35 +3,36 @@
 ## Overview
 
 MicroPDProxy supports multiple scheduling policies that control how incoming
-requests are distributed across backend decode (and prefill) nodes. Different
-workloads have different needs — some benefit from even distribution, others
-from session affinity or cache locality. The scheduling policy is selected via
-the `scheduling` field in the YAML configuration file.
+requests are distributed across backend decode (and prefill) instances.
+Different workloads have different needs — some benefit from even distribution,
+others from session affinity or cache locality. The scheduling policy is
+selected via the `scheduling` field in the YAML configuration file.
 
 ## Round Robin
 
 **Status:** Implemented
 
-Round Robin distributes requests to backend nodes in a fixed cyclic order.
-Each node receives one request before the cycle repeats.
+Round Robin distributes requests to backend instances in a fixed cyclic order.
+Each instance receives one request before the cycle repeats.
 
 ### How It Works
 
 The scheduler maintains an internal counter. On each request, the counter
-increments and the request is forwarded to `nodes[counter % len(nodes)]`.
+increments and the request is forwarded to `instances[counter % len(instances)]`.
 
 ### Characteristics
 
-- **Predictable** — every node gets exactly the same number of requests over
-  time (assuming no failures).
-- **No load awareness** — a slow node receives the same traffic as a fast one.
+- **Predictable** — every instance gets exactly the same number of requests
+  over time (assuming no failures).
+- **No load awareness** — a slow instance receives the same traffic as a fast
+  one.
 - **No session affinity** — consecutive requests from the same user may hit
-  different nodes.
+  different instances.
 - **Zero overhead** — no state beyond a single integer counter.
 
 ### When to Use
 
-- All backend nodes are identical in capacity.
+- All backend instances are identical in capacity.
 - Request processing times are uniform.
 - You want the simplest possible distribution.
 
@@ -48,27 +49,28 @@ No additional parameters.
 **Status:** Implemented
 
 Load Balanced routing tracks the number of active (in-flight) requests on each
-node and sends new requests to the node with the fewest active requests.
+instance and sends new requests to the instance with the fewest active
+requests.
 
 ### How It Works
 
-The scheduler maintains a per-node active request counter. When a request
-arrives, the node with the lowest counter is selected. The counter increments
-on dispatch and decrements when the response completes (including streaming
-responses).
+The scheduler maintains a per-instance active request counter. When a request
+arrives, the instance with the lowest counter is selected. The counter
+increments on dispatch and decrements when the response completes (including
+streaming responses).
 
 ### Characteristics
 
-- **Load-aware** — naturally adapts to heterogeneous node performance.
+- **Load-aware** — naturally adapts to heterogeneous instance performance.
 - **No session affinity** — requests from the same user may land on different
-  nodes.
-- **Minimal overhead** — only per-node integer counters.
-- **Handles stragglers** — slow nodes accumulate active requests, causing
+  instances.
+- **Minimal overhead** — only per-instance integer counters.
+- **Handles stragglers** — slow instances accumulate active requests, causing
   new traffic to flow elsewhere.
 
 ### When to Use
 
-- Backend nodes have different capacities or response times.
+- Backend instances have different capacities or response times.
 - Request durations vary significantly.
 - You want automatic adaptation without manual tuning.
 
@@ -85,13 +87,13 @@ No additional parameters. This is the **default** policy.
 **Status:** Planned (see Task 10a)
 
 Consistent Hash routes requests from the same session or user to the same
-backend node, enabling KV cache reuse across multi-turn conversations.
+backend instance, enabling KV cache reuse across multi-turn conversations.
 
 ### How It Works
 
-The scheduler hashes a session identifier to select a node from a hash ring.
-When a node is removed, only sessions mapped to that node are redistributed —
-all other mappings remain stable.
+The scheduler hashes a session identifier to select an instance from a hash
+ring. When an instance is removed, only sessions mapped to that instance are
+redistributed — all other mappings remain stable.
 
 ### Hash Key Priority
 
@@ -105,7 +107,7 @@ The scheduler determines the hash key using the following priority:
 
 - Multi-turn conversations where KV cache reuse reduces latency.
 - Workloads with natural session identifiers.
-- You want minimal disruption when nodes are added or removed.
+- You want minimal disruption when instances are added or removed.
 
 ### Configuration
 
@@ -119,18 +121,19 @@ consistent_hash:
 
 **Status:** Planned (see Task 10b)
 
-Power of Two Choices picks two random backend nodes and forwards the request to
-whichever has fewer active requests.
+Power of Two Choices picks two random backend instances and forwards the
+request to whichever has fewer active requests.
 
 ### How It Works
 
-On each request, the scheduler randomly selects two candidate nodes, queries
-their active request counts, and routes to the less loaded one. This achieves
-near-optimal load distribution with O(1) overhead — no need to scan all nodes.
+On each request, the scheduler randomly selects two candidate instances,
+queries their active request counts, and routes to the less loaded one. This
+achieves near-optimal load distribution with O(1) overhead — no need to scan
+all instances.
 
 ### When to Use
 
-- Large clusters where scanning all nodes is expensive.
+- Large clusters where scanning all instances is expensive.
 - You want load awareness without the complexity of a full least-connections
   algorithm.
 - Workloads with high request rates where per-request overhead matters.
@@ -147,15 +150,15 @@ No additional parameters.
 
 **Status:** Planned (see Task 10c)
 
-Cache-Aware routing hashes the prompt prefix to select a backend node,
+Cache-Aware routing hashes the prompt prefix to select a backend instance,
 maximizing prefix cache hits across requests with similar prompts.
 
 ### How It Works
 
 The scheduler extracts the first N tokens of the prompt, hashes them, and maps
-the hash to a backend node. Requests sharing the same prompt prefix are routed
-to the same node, increasing the likelihood that the node's KV cache already
-contains the prefix computation.
+the hash to a backend instance. Requests sharing the same prompt prefix are
+routed to the same instance, increasing the likelihood that the instance's KV
+cache already contains the prefix computation.
 
 ### When to Use
 
@@ -191,9 +194,9 @@ by name, without modifying existing code.
 | Policy | Load Aware | Session Affinity | Cache Friendly | Overhead | Best For |
 |---|---|---|---|---|---|
 | Round Robin | No | No | No | O(1) | Homogeneous clusters, uniform requests |
-| Load Balanced | Yes | No | No | O(N) | Heterogeneous nodes, variable latency |
+| Load Balanced | Yes | No | No | O(N) | Heterogeneous instances, variable latency |
 | Consistent Hash *(planned)* | No | Yes | Partial | O(1) | Multi-turn conversations, KV cache reuse |
 | Power of Two *(planned)* | Yes | No | No | O(1) | Large clusters, high throughput |
 | Cache-Aware *(planned)* | No | Prompt-based | Yes | O(1) | Shared system prompts, prefix caching |
 
-> **N** = number of backend nodes.
+> **N** = number of backend instances.


### PR DESCRIPTION
The proxy manages instances (ip:port endpoints), not physical nodes. A single node can host multiple instances.

## Changes

- **docs/resilience.md**: Replaced all "node" references with "instance" where referring to managed prefill/decode endpoints (per-node → per-instance, dead nodes → dead instances, etc.). Updated ASCII diagrams, API tables, examples, and troubleshooting.
- **docs/scheduling.md**: Same terminology fix — backend "nodes" → "instances" throughout.
- **docs/configuration.md**: No changes — "node" correctly refers to physical machines there (e.g. `world_size_per_node`, `nodes` list).