### PR TITLE
feat: resilience module with retry, exponential backoff and jitter (Task 9c)

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -38,9 +38,9 @@ class CircuitBreakerConfig(BaseModel):
     window_duration_seconds: int = 60
 
 try:
-    from .retry import RetryConfig
+    from .resilience import ResilienceConfig
 except ImportError:
-    from retry import RetryConfig
+    from resilience import ResilienceConfig
 
 try:
     from .topology import expand_topology
@@ -76,7 +76,7 @@ class ProxyConfig(BaseModel):
     probe_interval_seconds: int = 10
     health_check: HealthCheckConfig = HealthCheckConfig()
     circuit_breaker: CircuitBreakerConfig = CircuitBreakerConfig()
-    retry: RetryConfig = RetryConfig()
+    retry: ResilienceConfig = ResilienceConfig()
 
     # ------------------------------------------------------------------
     # Validators
@@ -341,6 +341,6 @@ class ProxyConfig(BaseModel):
 
         # 8. Retry config (YAML only, no CLI override)
         if retry_raw is not None:
-            merged["retry"] = RetryConfig(**retry_raw)
+            merged["retry"] = ResilienceConfig(**retry_raw)
 
         return cls(**merged)

--- a/core/resilience.py
+++ b/core/resilience.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Retry with exponential backoff with exponential backoff and jitter.
+"""Resilience module with retry, exponential backoff and jitter.
 
-Provides :class:`RetryConfig` (Pydantic model for YAML configuration)
-and :class:`RetryHandler` which executes a request function with automatic
+Provides :class:`ResilienceConfig` (Pydantic model for YAML configuration)
+and :class:`ResilienceHandler` which executes a request function with automatic
 retry on transient failures, selecting a different backend instance for
 each attempt.
 """
@@ -19,8 +19,8 @@ from pydantic import BaseModel, ConfigDict
 logger = logging.getLogger(__name__)
 
 
-class RetryConfig(BaseModel):
-    """Configuration for retry with exponential backoff + jitter."""
+class ResilienceConfig(BaseModel):
+    """Configuration for resilience (retry) with exponential backoff + jitter."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -52,14 +52,14 @@ def compute_backoff(
     return delay * (1.0 + jitter)
 
 
-class RetryHandler:
-    """Execute requests with retry (retry, backoff, and instance re-selection).
+class ResilienceHandler:
+    """Execute requests with resilience (retry, backoff, and instance re-selection).
 
     Uses dependency injection (callback functions) rather than importing
     the registry directly, keeping the module decoupled.
     """
 
-    def __init__(self, config: RetryConfig) -> None:
+    def __init__(self, config: ResilienceConfig) -> None:
         self.config = config
 
     def _should_retry(self, status_code: int, is_streaming: bool) -> bool:

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for core/retry.py — retry with exponential backoff + jitter."""
+"""Tests for core/resilience.py — resilience with exponential backoff + jitter."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ import types
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from retry import RetryConfig, RetryHandler, compute_backoff
+from resilience import ResilienceConfig, ResilienceHandler, compute_backoff
 
 # ---------------------------------------------------------------------------
 # compute_backoff
@@ -45,7 +45,7 @@ class TestComputeBackoff:
 
 
 # ---------------------------------------------------------------------------
-# RetryHandler._should_retry
+# ResilienceHandler._should_retry
 # ---------------------------------------------------------------------------
 
 
@@ -53,7 +53,7 @@ class TestShouldRetry:
     """Verify retry eligibility logic."""
 
     def setup_method(self):
-        self.handler = RetryHandler(RetryConfig())
+        self.handler = ResilienceHandler(ResilienceConfig())
 
     def test_no_retry_4xx(self):
         for code in (400, 401, 403, 404, 422, 499):
@@ -75,14 +75,14 @@ class TestShouldRetry:
         assert self.handler._should_retry(501, False) is False
 
     def test_custom_retryable_codes(self):
-        config = RetryConfig(retryable_status_codes=[418, 500])
-        handler = RetryHandler(config)
+        config = ResilienceConfig(retryable_status_codes=[418, 500])
+        handler = ResilienceHandler(config)
         assert handler._should_retry(418, False) is True
         assert handler._should_retry(502, False) is False
 
 
 # ---------------------------------------------------------------------------
-# RetryHandler.execute
+# ResilienceHandler.execute
 # ---------------------------------------------------------------------------
 
 
@@ -98,8 +98,8 @@ class TestRetryExecute:
 
     @pytest.mark.asyncio
     async def test_success_no_retry(self):
-        config = RetryConfig(enabled=True, max_retries=2)
-        handler = RetryHandler(config)
+        config = ResilienceConfig(enabled=True, max_retries=2)
+        handler = ResilienceHandler(config)
         resp_ok = _make_response(200)
 
         request_fn = AsyncMock(return_value=resp_ok)
@@ -111,13 +111,13 @@ class TestRetryExecute:
 
     @pytest.mark.asyncio
     async def test_retry_then_success(self):
-        config = RetryConfig(
+        config = ResilienceConfig(
             enabled=True,
             max_retries=2,
             initial_backoff_ms=1,  # tiny for fast test
             jitter_factor=0.0,
         )
-        handler = RetryHandler(config)
+        handler = ResilienceHandler(config)
 
         responses = [_make_response(502), _make_response(200)]
         request_fn = AsyncMock(side_effect=responses)
@@ -130,13 +130,13 @@ class TestRetryExecute:
 
     @pytest.mark.asyncio
     async def test_all_retries_fail(self):
-        config = RetryConfig(
+        config = ResilienceConfig(
             enabled=True,
             max_retries=2,
             initial_backoff_ms=1,
             jitter_factor=0.0,
         )
-        handler = RetryHandler(config)
+        handler = ResilienceHandler(config)
 
         responses = [_make_response(502), _make_response(503), _make_response(500)]
         request_fn = AsyncMock(side_effect=responses)
@@ -151,8 +151,8 @@ class TestRetryExecute:
 
     @pytest.mark.asyncio
     async def test_no_retry_on_4xx(self):
-        config = RetryConfig(enabled=True, max_retries=2, initial_backoff_ms=1)
-        handler = RetryHandler(config)
+        config = ResilienceConfig(enabled=True, max_retries=2, initial_backoff_ms=1)
+        handler = ResilienceHandler(config)
 
         request_fn = AsyncMock(return_value=_make_response(404))
         select_fn = MagicMock(return_value="10.0.0.1:8200")
@@ -163,8 +163,8 @@ class TestRetryExecute:
 
     @pytest.mark.asyncio
     async def test_no_retry_on_streaming(self):
-        config = RetryConfig(enabled=True, max_retries=2, initial_backoff_ms=1)
-        handler = RetryHandler(config)
+        config = ResilienceConfig(enabled=True, max_retries=2, initial_backoff_ms=1)
+        handler = ResilienceHandler(config)
 
         request_fn = AsyncMock(return_value=_make_response(502, is_streaming=True))
         select_fn = MagicMock(return_value="10.0.0.1:8200")
@@ -175,13 +175,13 @@ class TestRetryExecute:
 
     @pytest.mark.asyncio
     async def test_callbacks_invoked(self):
-        config = RetryConfig(
+        config = ResilienceConfig(
             enabled=True,
             max_retries=1,
             initial_backoff_ms=1,
             jitter_factor=0.0,
         )
-        handler = RetryHandler(config)
+        handler = ResilienceHandler(config)
 
         responses = [_make_response(502), _make_response(200)]
         request_fn = AsyncMock(side_effect=responses)
@@ -201,8 +201,8 @@ class TestRetryExecute:
     @pytest.mark.anyio
     async def test_disabled_single_attempt_success(self):
         """When enabled=False, exactly one attempt is made (no retry)."""
-        cfg = RetryConfig(enabled=False, max_retries=3)
-        handler = RetryHandler(cfg)
+        cfg = ResilienceConfig(enabled=False, max_retries=3)
+        handler = ResilienceHandler(cfg)
         resp = MagicMock(status_code=200)
         request_fn = AsyncMock(return_value=resp)
         select_fn = MagicMock(return_value="node-1")
@@ -215,8 +215,8 @@ class TestRetryExecute:
     @pytest.mark.anyio
     async def test_disabled_single_attempt_failure(self):
         """When enabled=False and request fails, no retry is attempted."""
-        cfg = RetryConfig(enabled=False, max_retries=3)
-        handler = RetryHandler(cfg)
+        cfg = ResilienceConfig(enabled=False, max_retries=3)
+        handler = ResilienceHandler(cfg)
         resp = MagicMock(status_code=502)
         request_fn = AsyncMock(return_value=resp)
         select_fn = MagicMock(return_value="node-1")
@@ -229,8 +229,8 @@ class TestRetryExecute:
     @pytest.mark.anyio
     async def test_select_instance_returns_none(self):
         """When select_instance_fn returns None during retry, stop retrying."""
-        cfg = RetryConfig(enabled=True, max_retries=2, initial_backoff_ms=1)
-        handler = RetryHandler(cfg)
+        cfg = ResilienceConfig(enabled=True, max_retries=2, initial_backoff_ms=1)
+        handler = ResilienceHandler(cfg)
         resp = MagicMock(status_code=502)
         request_fn = AsyncMock(return_value=resp)
         call_count = 0
@@ -250,8 +250,8 @@ class TestRetryExecute:
     @pytest.mark.anyio
     async def test_select_instance_raises(self):
         """When select_instance_fn raises during retry, stop retrying."""
-        cfg = RetryConfig(enabled=True, max_retries=2, initial_backoff_ms=1)
-        handler = RetryHandler(cfg)
+        cfg = ResilienceConfig(enabled=True, max_retries=2, initial_backoff_ms=1)
+        handler = ResilienceHandler(cfg)
         resp = MagicMock(status_code=502)
         request_fn = AsyncMock(return_value=resp)
         call_count = 0
@@ -274,11 +274,11 @@ class TestRetryExecute:
 # ---------------------------------------------------------------------------
 
 
-class TestRetryConfigYAML:
-    """Verify RetryConfig integrates with ProxyConfig."""
+class TestResilienceConfigYAML:
+    """Verify ResilienceConfig integrates with ProxyConfig."""
 
     def test_default_disabled(self):
-        config = RetryConfig()
+        config = ResilienceConfig()
         assert config.enabled is False
         assert config.max_retries == 2
 


### PR DESCRIPTION
## Summary

Implement Task 9c: Resilience module with retry, exponential backoff and jitter.

### Changes

**core/resilience.py** (new)
- `ResilienceConfig` — Pydantic model with YAML configuration (disabled by default, YAML key: `retry:`)
- `compute_backoff()` — exponential backoff with configurable jitter
- `ResilienceHandler` — executes requests with automatic retry on transient failures
  - Selects different backend instances for each retry attempt
  - Does not retry 4xx (except explicitly configured codes like 408/429)
  - Does not retry streaming responses
  - Short-circuits to single attempt when `enabled=False`
  - Gracefully handles `select_instance_fn` returning None or raising

**core/config.py**
- Integrates `ResilienceConfig` into `ProxyConfig` (YAML key: `retry:`)

**tests/test_resilience.py**
- Comprehensive tests: backoff math, retry eligibility, all execute paths, YAML integration

### Design Notes
- Module/class naming uses `resilience` (ResilienceConfig, ResilienceHandler)
- YAML configuration key remains `retry:` per tasklist_openclaw.md spec
- Fixed duplicate phrase in module docstring (reported in review nits)