### PR TITLE
feat: Policy Registry for extensible scheduling strategies (Task 10d)

### DIFF
--- a/core/scheduler/__init__.py
+++ b/core/scheduler/__init__.py
@@ -5,13 +5,17 @@ try:
     from .scheduler_base import SchedulingPolicy
     from .round_robin import RoundRobinSchedulingPolicy
     from .load_balanced import LoadBalancedScheduler
+    from .policy_registry import PolicyRegistry, default_registry
 except ImportError:
     from scheduler_base import SchedulingPolicy
     from round_robin import RoundRobinSchedulingPolicy
     from load_balanced import LoadBalancedScheduler
+    from policy_registry import PolicyRegistry, default_registry
 
 __all__ = [
     "SchedulingPolicy",
     "RoundRobinSchedulingPolicy",
     "LoadBalancedScheduler",
+    "PolicyRegistry",
+    "default_registry",
 ]

--- a/core/scheduler/policy_registry.py
+++ b/core/scheduler/policy_registry.py
@@ -3,11 +3,14 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from .load_balanced import LoadBalancedScheduler
 from .round_robin import RoundRobinSchedulingPolicy
 from .scheduler_base import SchedulingPolicy
+
+logger = logging.getLogger(__name__)
 
 
 class PolicyRegistry:
@@ -21,7 +24,24 @@ class PolicyRegistry:
         self._policies: dict[str, type[SchedulingPolicy]] = {}
 
     def register(self, name: str, policy_cls: type) -> None:
-        """Register a scheduling policy class under *name*."""
+        """Register a scheduling policy class under *name*.
+
+        Raises:
+            TypeError: If *policy_cls* is not a subclass of
+                :class:`SchedulingPolicy`.
+        """
+        if not (isinstance(policy_cls, type)
+                and issubclass(policy_cls, SchedulingPolicy)):
+            raise TypeError(
+                f"{policy_cls!r} is not a subclass of SchedulingPolicy"
+            )
+        if name in self._policies:
+            logger.warning(
+                "Overwriting existing policy %r (%s) with %s",
+                name,
+                self._policies[name].__name__,
+                policy_cls.__name__,
+            )
         self._policies[name] = policy_cls
 
     def create(self, name: str, **kwargs: Any) -> SchedulingPolicy:

--- a/tests/test_policy_registry.py
+++ b/tests/test_policy_registry.py
@@ -55,6 +55,26 @@ class TestPolicyRegistry:
         reg = PolicyRegistry()
         assert not reg.has("missing")
 
+    def test_register_non_policy_raises_type_error(self):
+        """Registering a class that is not a SchedulingPolicy raises TypeError."""
+        reg = PolicyRegistry()
+        with pytest.raises(TypeError, match="not a subclass of SchedulingPolicy"):
+            reg.register("bad", dict)
+
+    def test_register_non_class_raises_type_error(self):
+        """Registering a non-class object raises TypeError."""
+        reg = PolicyRegistry()
+        with pytest.raises(TypeError, match="not a subclass of SchedulingPolicy"):
+            reg.register("bad", "not_a_class")
+
+    def test_duplicate_register_warns(self, caplog):
+        """Re-registering the same name logs a warning."""
+        reg = PolicyRegistry()
+        reg.register("dup", _DummyPolicy)
+        with caplog.at_level("WARNING"):
+            reg.register("dup", _DummyPolicy)
+        assert "Overwriting existing policy" in caplog.text
+
     def test_create_returns_correct_type(self):
         """create() returns an instance of the registered class."""
         rr = default_registry.create("roundrobin")


### PR DESCRIPTION
## Summary

Implements Task 10d: Policy Registry — an extensible factory pattern for scheduling strategies.

## Changes

- **`core/scheduler/policy_registry.py`**: New `PolicyRegistry` class with:
  - `register(name, policy_cls)` — register a policy by name, with `issubclass(SchedulingPolicy)` type check
  - `create(name, **kwargs)` — instantiate a registered policy
  - `has(name)` — check if a policy is registered
  - `list_policies()` — list all registered policy names (sorted)
  - Module-level `default_registry` singleton with `roundrobin` and `loadbalanced` pre-registered
  - Duplicate registration logs a warning instead of silent overwrite
  - Placeholder comments for future `consistent_hash`, `power_of_two`, `cache_aware` policies
  - Unknown policy names raise `ValueError`

- **`core/scheduler/__init__.py`**: Exports `PolicyRegistry` and `default_registry`

- **`tests/test_policy_registry.py`**: 9 unit tests covering:
  - `test_register_and_select` — register + create with kwargs
  - `test_unknown_policy_raises` — ValueError for missing policies
  - `test_builtin_policies_registered` — default registry has builtins
  - `test_list_policies_sorted` — sorted output
  - `test_has_returns_false_for_missing` — negative case
  - `test_register_non_policy_raises_type_error` — TypeError for non-SchedulingPolicy class
  - `test_register_non_class_raises_type_error` — TypeError for non-class objects
  - `test_duplicate_register_warns` — warning on overwrite
  - `test_create_returns_correct_type` — instances are SchedulingPolicy

## Note on MicroPDProxyServer integration

`MicroPDProxyServer.py` still uses hardcoded if/else for policy selection. **This is intentionally deferred** to a follow-up integration PR to keep this PR focused on the registry infrastructure. The integration PR will replace the if/else with `default_registry.create(config.scheduling, ...)`.

## Testing

```
pre-commit run --all-files  ✅
pytest tests/test_policy_registry.py -v  ✅ (9/9 passed)
```