### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xpyd"
-version = "1.0.0"
+version = "1.1.0"
 description = "Lightweight Prefill-Decode proxy for disaggregated LLM serving"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/xpyd/proxy.py
+++ b/xpyd/proxy.py
@@ -579,7 +579,7 @@ class ProxyServer:
         server.run()
 
 
-_VERSION = "0.1.0"
+_VERSION = "1.1.0"
 
 
 def _build_parser():


### PR DESCRIPTION
## Summary

Bump version from 1.0.0 to 1.1.0.

### Changes

- `pyproject.toml`: `version = "1.0.0"` → `"1.1.0"`
- `xpyd/proxy.py`: `_VERSION = "0.1.0"` → `"1.1.0"`

Note: `_VERSION` in proxy.py was out of sync at `0.1.0` — corrected to match pyproject.toml.

### Test Results

427 tests pass, pre-commit clean.