### PR TITLE
Expand CPU API lifecycle coverage

### DIFF
--- a/.github/workflows/cpu-example.yml
+++ b/.github/workflows/cpu-example.yml
@@ -24,8 +24,8 @@ jobs:
         with:
           path: |
             ~/.cache/pip
-            /tmp/opt-125m
-          key: cpu-example-vllm-0.25.2.dev202607190821-opt-125m
+            /tmp/tokenizers/facebook/opt-125m
+          key: cpu-example-vllm-0.25.2.dev202607190821-tokenizers-opt-125m
       - name: Install xPyD and vLLM CPU
         run: |
           python -m venv .venv

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@
 MicroDisaggregatedProxy uses YAML-based configuration as the primary way to define proxy
 behavior. YAML provides a structured, readable format that scales better than
 CLI arguments as the number of configuration options grows. A single YAML file
-captures the entire proxy topology — model path, node addresses, tensor/data
+captures the entire proxy topology — model names, tokenizer source, node addresses, tensor/data
 parallelism parameters, scheduling policy, and authentication — making
 deployments reproducible and version-controllable.
 
@@ -17,7 +17,9 @@ Below is the complete schema with every supported field.
 # MicroDisaggregatedProxy Configuration
 
 # Server
-model: /path/to/model           # required
+model: my-model                # required in legacy single-model mode
+# Optional local root; model "org/name" maps to "<root>/org/name/"
+# tokenizer_path: /models/tokenizers
 port: 8000                      # default: 8000
 log_level: warning              # debug | info | warning | error
 
@@ -59,7 +61,8 @@ startup:
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `model` | string | **yes** | — | Path to the model directory or tokenizer. Used by the proxy to validate requests. |
+| `model` | string | single-model only | — | Served model name in legacy single-model configuration. |
+| `tokenizer_path` | string | no | — | Local tokenizer root. Model `org/name` must exist at `<tokenizer_path>/org/name/`. |
 | `port` | integer | no | `8000` | TCP port the proxy listens on. |
 | `log_level` | string | no | `warning` | Logging verbosity. One of `debug`, `info`, `warning`, `error`. |
 | `prefill.nodes` | list[string] | **yes** | — | Addresses of prefill backend nodes in `"ip:port"` format. |
@@ -78,6 +81,22 @@ startup:
 | `startup.wait_timeout_seconds` | integer | no | `600` | Maximum time (seconds) to wait for at least 1 prefill + 1 decode node during startup. |
 | `startup.probe_interval_seconds` | integer | no | `10` | Interval (seconds) between health probes during startup discovery. |
 | `startup.heartbeat_interval_seconds` | number | no | `30` | Interval between logs of the deployment mode and online P/D node counts. |
+
+### Tokenizer loading and scheduler fallback
+
+When `tokenizer_path` is set, xPyD strictly loads each model from its
+model-named subdirectory. For example, model `facebook/opt-125m` must have
+valid Hugging Face tokenizer files in
+`<tokenizer_path>/facebook/opt-125m/`. A missing directory or invalid
+tokenizer is a configuration error and stops the proxy with the expected
+path in the error message.
+
+Without `tokenizer_path`, xPyD downloads each discovered model's tokenizer
+through `AutoTokenizer.from_pretrained()`. Successful loads use the configured
+scheduler, which defaults to `loadbalanced`. A failed download emits a warning
+and downgrades only that model to `roundrobin`. P/D modes continue operating;
+when ZMQ needs exact token IDs, xPyD uses a healthy prefill backend's
+`/tokenize` endpoint.
 
 ### ZMQ receiver token alignment
 

--- a/examples/aggregated/opt-125m-cpu/README.md
+++ b/examples/aggregated/opt-125m-cpu/README.md
@@ -17,5 +17,6 @@ pip install -e .
 ```
 
 The check starts xPyD before vLLM, verifies offline inference returns HTTP 503,
-discovers the backend, runs real inference, validates node loss, and confirms
+auto-detects the served model from the backend, exercises completion, chat,
+streaming, health, models, and metrics APIs, validates node loss, and confirms
 reconnection. Runtime output is stored in the ignored `logs/` directory.

--- a/examples/aggregated/opt-125m-cpu/README.md
+++ b/examples/aggregated/opt-125m-cpu/README.md
@@ -19,4 +19,8 @@ pip install -e .
 The check starts xPyD before vLLM, verifies offline inference returns HTTP 503,
 auto-detects the served model from the backend, exercises completion, chat,
 streaming, health, models, and metrics APIs, validates node loss, and confirms
-reconnection. Runtime output is stored in the ignored `logs/` directory.
+reconnection. It then uses an isolated Hugging Face cache to verify a real
+automatic tokenizer download, restarts with another empty cache in offline
+mode, and confirms inference continues after the tokenizer load warning and
+round-robin fallback. Runtime output is stored in the ignored `logs/`
+directory.

--- a/examples/aggregated/opt-125m-cpu/download_model.sh
+++ b/examples/aggregated/opt-125m-cpu/download_model.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-MODEL_DIR="${MODEL_DIR:-/tmp/opt-125m}"
+MODEL_DIR="${MODEL_DIR:-/tmp/tokenizers/facebook/opt-125m}"
 MODEL_URL="${MODEL_URL:-https://github.com/LMCache/opt-125m/releases/download/v1.0/opt-125m.tar.gz}"
 
 configure_chat_template() {

--- a/examples/aggregated/opt-125m-cpu/download_model.sh
+++ b/examples/aggregated/opt-125m-cpu/download_model.sh
@@ -5,7 +5,31 @@ set -euo pipefail
 MODEL_DIR="${MODEL_DIR:-/tmp/opt-125m}"
 MODEL_URL="${MODEL_URL:-https://github.com/LMCache/opt-125m/releases/download/v1.0/opt-125m.tar.gz}"
 
+configure_chat_template() {
+    python - "${MODEL_DIR}/tokenizer_config.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+config = json.loads(path.read_text())
+config["chat_template"] = (
+    "{% for message in messages %}"
+    "{{'<|im_start|>' + message['role'] + '\\n' + message['content']}}"
+    "{% if (loop.last and add_generation_prompt) or not loop.last %}"
+    "{{ '<|im_end|>' + '\\n'}}"
+    "{% endif %}"
+    "{% endfor %}"
+    "{% if add_generation_prompt and messages[-1]['role'] != 'assistant' %}"
+    "{{ '<|im_start|>assistant\\n' }}"
+    "{% endif %}"
+)
+path.write_text(json.dumps(config, indent=2) + "\n")
+PY
+}
+
 if [[ -f "${MODEL_DIR}/pytorch_model.bin" ]]; then
+    configure_chat_template
     echo "OPT-125M already available at ${MODEL_DIR}."
     exit 0
 fi
@@ -34,4 +58,5 @@ fi
 mkdir -p "${MODEL_DIR}"
 cp -a "${extract_dir}/${top_dir}/." "${MODEL_DIR}/"
 test -f "${MODEL_DIR}/pytorch_model.bin"
+configure_chat_template
 echo "Downloaded OPT-125M to ${MODEL_DIR}."

--- a/examples/aggregated/opt-125m-cpu/run_all.sh
+++ b/examples/aggregated/opt-125m-cpu/run_all.sh
@@ -6,6 +6,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROXY_ENDPOINT="${PROXY_ENDPOINT:-http://127.0.0.1:8868}"
 BACKEND_ENDPOINT="${BACKEND_ENDPOINT:-http://127.0.0.1:8000}"
 LOG_DIR="${SCRIPT_DIR}/logs"
+LOCAL_CONFIG="${SCRIPT_DIR}/xpyd_aggregated.yaml"
+AUTO_CONFIG="${SCRIPT_DIR}/xpyd_aggregated_auto.yaml"
+AUTO_SUCCESS_CACHE="${LOG_DIR}/hf-auto-success"
+AUTO_FAILURE_CACHE="${LOG_DIR}/hf-auto-failure"
 PROXY_PID=""
 BACKEND_PID=""
 
@@ -53,6 +57,22 @@ wait_for_log_count() {
         }
         sleep 1
     done
+}
+
+start_proxy() {
+    local config=$1
+    shift
+    env CONFIG_FILE="${config}" "$@" \
+        bash "${SCRIPT_DIR}/start_proxy.sh" >>"${LOG_DIR}/proxy.log" 2>&1 &
+    PROXY_PID=$!
+    wait_for_url "${PROXY_ENDPOINT}/status/instances" "${PROXY_PID}"
+}
+
+stop_proxy() {
+    kill "${PROXY_PID}"
+    wait "${PROXY_PID}" 2>/dev/null || true
+    PROXY_PID=""
+    wait_for_port_close "${PROXY_ENDPOINT}/status/instances"
 }
 
 wait_for_instance_status() {
@@ -150,13 +170,12 @@ stop_backend() {
 trap cleanup EXIT INT TERM
 
 mkdir -p "${LOG_DIR}"
+rm -rf "${AUTO_SUCCESS_CACHE}" "${AUTO_FAILURE_CACHE}"
 : >"${LOG_DIR}/proxy.log"
 : >"${LOG_DIR}/vllm.log"
 
 echo "=== Phase 1: proxy-first startup with backend offline ==="
-bash "${SCRIPT_DIR}/start_proxy.sh" >"${LOG_DIR}/proxy.log" 2>&1 &
-PROXY_PID=$!
-wait_for_url "${PROXY_ENDPOINT}/status/instances" "${PROXY_PID}"
+start_proxy "${LOCAL_CONFIG}"
 wait_for_instance_status unhealthy
 assert_inference_status 503
 
@@ -176,6 +195,27 @@ start_backend
 wait_for_discovered_model
 wait_for_log_count "Node heartbeat | mode=aggregated | aggregated=1/1 online" 2
 bash "${SCRIPT_DIR}/smoke_test.sh"
+
+echo "=== Phase 5: automatic tokenizer download ==="
+stop_proxy
+start_proxy "${AUTO_CONFIG}" "HF_HOME=${AUTO_SUCCESS_CACHE}"
+wait_for_instance_status healthy
+wait_for_discovered_model
+wait_for_log_count \
+    "Loaded tokenizer for model 'facebook/opt-125m' from facebook/opt-125m" 1
+assert_inference_status 200
+
+echo "=== Phase 6: tokenizer download failure and round-robin fallback ==="
+stop_proxy
+start_proxy "${AUTO_CONFIG}" \
+    "HF_HOME=${AUTO_FAILURE_CACHE}" \
+    "HF_HUB_OFFLINE=1" \
+    "TRANSFORMERS_OFFLINE=1"
+wait_for_instance_status healthy
+wait_for_discovered_model
+wait_for_log_count \
+    "Falling back to roundrobin scheduling for this model." 1
+assert_inference_status 200
 
 grep -q "Node heartbeat | mode=aggregated | aggregated=0/1 online" \
     "${LOG_DIR}/proxy.log"

--- a/examples/aggregated/opt-125m-cpu/run_all.sh
+++ b/examples/aggregated/opt-125m-cpu/run_all.sh
@@ -82,6 +82,38 @@ raise SystemExit(
     done
 }
 
+wait_for_discovered_model() {
+    local deadline=$((SECONDS + 60))
+    until curl --silent --fail --max-time 2 \
+        "${PROXY_ENDPOINT}/v1/models" |
+        python -c '
+import json
+import sys
+
+models = json.load(sys.stdin)
+raise SystemExit(
+    0
+    if models == {
+        "object": "list",
+        "data": [{
+            "id": "facebook/opt-125m",
+            "object": "model",
+            "created": 0,
+            "owned_by": "system",
+        }],
+    }
+    else 1
+)
+'; do
+        (( SECONDS < deadline )) || {
+            echo "ERROR: proxy did not auto-detect facebook/opt-125m." >&2
+            curl --silent "${PROXY_ENDPOINT}/v1/models" >&2 || true
+            return 1
+        }
+        sleep 1
+    done
+}
+
 assert_inference_status() {
     local expected=$1 actual
     actual="$(
@@ -130,6 +162,8 @@ assert_inference_status 503
 
 echo "=== Phase 2: node discovery and inference ==="
 start_backend
+wait_for_discovered_model
+wait_for_log_count "Auto-detected model 'facebook/opt-125m' on 127.0.0.1:8000" 1
 wait_for_log_count "Node heartbeat | mode=aggregated | aggregated=1/1 online" 1
 bash "${SCRIPT_DIR}/smoke_test.sh"
 
@@ -139,6 +173,7 @@ assert_inference_status 503
 
 echo "=== Phase 4: node reconnection ==="
 start_backend
+wait_for_discovered_model
 wait_for_log_count "Node heartbeat | mode=aggregated | aggregated=1/1 online" 2
 bash "${SCRIPT_DIR}/smoke_test.sh"
 

--- a/examples/aggregated/opt-125m-cpu/smoke_test.sh
+++ b/examples/aggregated/opt-125m-cpu/smoke_test.sh
@@ -3,8 +3,10 @@
 set -euo pipefail
 
 PROXY_ENDPOINT="${PROXY_ENDPOINT:-http://127.0.0.1:8868}"
+MODEL="facebook/opt-125m"
+CHAT_TEMPLATE="{% for message in messages %}{{ message['role'] + ': ' + message['content'] + '\n' }}{% endfor %}assistant: "
 
-response="$(
+completion="$(
     curl --fail --silent --show-error \
         "${PROXY_ENDPOINT}/v1/completions" \
         -H "Content-Type: application/json" \
@@ -21,8 +23,138 @@ import json
 import sys
 
 output = json.load(sys.stdin)
+assert output["object"] == "text_completion", output
+assert output["model"] == "facebook/opt-125m", output
+assert isinstance(output["id"], str) and output["id"], output
+assert isinstance(output["created"], int), output
+assert len(output["choices"]) == 1, output
+assert output["choices"][0]["index"] == 0, output
 assert output["choices"][0]["text"], "empty completion"
+assert output["choices"][0]["finish_reason"] == "length", output
 assert output["usage"]["completion_tokens"] == 4, output["usage"]
-' <<<"${response}"
+' <<<"${completion}"
 
-echo "OPT-125M aggregated CPU inference passed."
+chat="$(
+    curl --fail --silent --show-error \
+        "${PROXY_ENDPOINT}/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -d "{
+            \"model\": \"${MODEL}\",
+            \"messages\": [{\"role\": \"user\", \"content\": \"Say hello\"}],
+            \"chat_template\": $(python -c 'import json, sys; print(json.dumps(sys.argv[1]))' "${CHAT_TEMPLATE}"),
+            \"max_tokens\": 4,
+            \"temperature\": 0
+        }"
+)"
+
+python -c '
+import json
+import sys
+
+output = json.load(sys.stdin)
+assert output["object"] == "chat.completion", output
+assert output["model"] == "facebook/opt-125m", output
+assert isinstance(output["id"], str) and output["id"], output
+assert isinstance(output["created"], int), output
+assert len(output["choices"]) == 1, output
+choice = output["choices"][0]
+assert choice["index"] == 0, output
+assert choice["message"]["role"] == "assistant", output
+assert choice["message"]["content"], output
+assert choice["finish_reason"] == "length", output
+assert output["usage"]["completion_tokens"] == 4, output["usage"]
+' <<<"${chat}"
+
+stream="$(
+    curl --fail --silent --show-error --no-buffer \
+        "${PROXY_ENDPOINT}/v1/completions" \
+        -H "Content-Type: application/json" \
+        -d '{
+            "model": "facebook/opt-125m",
+            "prompt": "The streaming proxy test says",
+            "max_tokens": 4,
+            "temperature": 0,
+            "stream": true,
+            "stream_options": {"include_usage": true}
+        }'
+)"
+
+python -c '
+import json
+import sys
+
+events = [
+    line.removeprefix("data: ")
+    for line in sys.stdin.read().splitlines()
+    if line.startswith("data: ")
+]
+assert events and events[-1] == "[DONE]", events
+chunks = [json.loads(event) for event in events[:-1]]
+assert chunks, events
+assert all(chunk["object"] == "text_completion" for chunk in chunks), chunks
+assert all(chunk["model"] == "facebook/opt-125m" for chunk in chunks), chunks
+assert "".join(
+    choice["text"]
+    for chunk in chunks
+    for choice in chunk["choices"]
+), chunks
+usage_chunks = [chunk["usage"] for chunk in chunks if chunk.get("usage")]
+assert usage_chunks[-1]["completion_tokens"] == 4, chunks
+' <<<"${stream}"
+
+health="$(
+    curl --fail --silent --show-error "${PROXY_ENDPOINT}/health"
+)"
+python -c '
+import json
+import sys
+
+output = json.load(sys.stdin)
+backend = output["127.0.0.1:8000"]
+assert backend["status"] == 200, output
+assert backend["type"] == "text", output
+' <<<"${health}"
+
+models="$(
+    curl --fail --silent --show-error "${PROXY_ENDPOINT}/v1/models"
+)"
+python -c '
+import json
+import sys
+
+output = json.load(sys.stdin)
+assert output["object"] == "list", output
+assert [model["id"] for model in output["data"]] == [
+    "facebook/opt-125m"
+], output
+' <<<"${models}"
+
+unsupported_media_status="$(
+    curl --silent --output /dev/null --write-out "%{http_code}" \
+        "${PROXY_ENDPOINT}/v1/completions" \
+        -H "Content-Type: text/plain" \
+        -d "not json"
+)"
+[[ "${unsupported_media_status}" == "415" ]]
+
+unknown_model_status="$(
+    curl --silent --output /dev/null --write-out "%{http_code}" \
+        "${PROXY_ENDPOINT}/v1/completions" \
+        -H "Content-Type: application/json" \
+        -d '{
+            "model": "unknown-model",
+            "prompt": "This must not be routed",
+            "max_tokens": 1
+        }'
+)"
+[[ "${unknown_model_status}" == "404" ]]
+
+metrics="$(
+    curl --fail --silent --show-error "${PROXY_ENDPOINT}/metrics"
+)"
+grep -q 'proxy_requests_total{endpoint="/v1/completions"}' <<<"${metrics}"
+grep -q 'proxy_requests_total{endpoint="/v1/chat/completions"}' <<<"${metrics}"
+grep -q "proxy_request_duration_seconds" <<<"${metrics}"
+grep -q "proxy_active_requests 0.0" <<<"${metrics}"
+
+echo "OPT-125M aggregated CPU API smoke tests passed."

--- a/examples/aggregated/opt-125m-cpu/smoke_test.sh
+++ b/examples/aggregated/opt-125m-cpu/smoke_test.sh
@@ -34,8 +34,8 @@ assert output["choices"][0]["finish_reason"] == "length", output
 assert output["usage"]["completion_tokens"] == 4, output["usage"]
 ' <<<"${completion}"
 
-chat="$(
-    curl --fail-with-body --silent --show-error \
+chat_result="$(
+    curl --silent --show-error --write-out $'\n%{http_code}' \
         "${PROXY_ENDPOINT}/v1/chat/completions" \
         -H "Content-Type: application/json" \
         -d "{
@@ -46,6 +46,12 @@ chat="$(
             \"temperature\": 0
         }"
 )"
+chat="${chat_result%$'\n'*}"
+chat_status="${chat_result##*$'\n'}"
+if [[ "${chat_status}" != "200" ]]; then
+    echo "ERROR: chat completion returned HTTP ${chat_status}: ${chat}" >&2
+    exit 1
+fi
 
 python -c '
 import json

--- a/examples/aggregated/opt-125m-cpu/smoke_test.sh
+++ b/examples/aggregated/opt-125m-cpu/smoke_test.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 
 PROXY_ENDPOINT="${PROXY_ENDPOINT:-http://127.0.0.1:8868}"
 MODEL="facebook/opt-125m"
-CHAT_TEMPLATE="{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content']}}{% if (loop.last and add_generation_prompt) or not loop.last %}{{ '<|im_end|>' + '\n'}}{% endif %}{% endfor %}{% if add_generation_prompt and messages[-1]['role'] != 'assistant' %}{{ '<|im_start|>assistant\n' }}{% endif %}"
 
 completion="$(
     curl --fail-with-body --silent --show-error \
@@ -41,7 +40,6 @@ chat_result="$(
         -d "{
             \"model\": \"${MODEL}\",
             \"messages\": [{\"role\": \"user\", \"content\": \"Say hello\"}],
-            \"chat_template\": $(python -c 'import json, sys; print(json.dumps(sys.argv[1]))' "${CHAT_TEMPLATE}"),
             \"max_tokens\": 4,
             \"temperature\": 0
         }"

--- a/examples/aggregated/opt-125m-cpu/smoke_test.sh
+++ b/examples/aggregated/opt-125m-cpu/smoke_test.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 
 PROXY_ENDPOINT="${PROXY_ENDPOINT:-http://127.0.0.1:8868}"
 MODEL="facebook/opt-125m"
-CHAT_TEMPLATE="{% for message in messages %}{{ message['role'] + ': ' + message['content'] + '\n' }}{% endfor %}assistant: "
+CHAT_TEMPLATE="{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content']}}{% if (loop.last and add_generation_prompt) or not loop.last %}{{ '<|im_end|>' + '\n'}}{% endif %}{% endfor %}{% if add_generation_prompt and messages[-1]['role'] != 'assistant' %}{{ '<|im_start|>assistant\n' }}{% endif %}"
 
 completion="$(
-    curl --fail --silent --show-error \
+    curl --fail-with-body --silent --show-error \
         "${PROXY_ENDPOINT}/v1/completions" \
         -H "Content-Type: application/json" \
         -d '{
@@ -35,7 +35,7 @@ assert output["usage"]["completion_tokens"] == 4, output["usage"]
 ' <<<"${completion}"
 
 chat="$(
-    curl --fail --silent --show-error \
+    curl --fail-with-body --silent --show-error \
         "${PROXY_ENDPOINT}/v1/chat/completions" \
         -H "Content-Type: application/json" \
         -d "{

--- a/examples/aggregated/opt-125m-cpu/start_proxy.sh
+++ b/examples/aggregated/opt-125m-cpu/start_proxy.sh
@@ -3,5 +3,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${CONFIG_FILE:-${SCRIPT_DIR}/xpyd_aggregated.yaml}"
 
-exec xpyd proxy --config "${SCRIPT_DIR}/xpyd_aggregated.yaml"
+exec xpyd proxy --config "${CONFIG_FILE}"

--- a/examples/aggregated/opt-125m-cpu/vllm_server.sh
+++ b/examples/aggregated/opt-125m-cpu/vllm_server.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-MODEL_DIR="${MODEL_DIR:-/tmp/opt-125m}"
+MODEL_DIR="${MODEL_DIR:-/tmp/tokenizers/facebook/opt-125m}"
 PORT="${PORT:-8000}"
 
 export GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-lo}"

--- a/examples/aggregated/opt-125m-cpu/xpyd_aggregated.yaml
+++ b/examples/aggregated/opt-125m-cpu/xpyd_aggregated.yaml
@@ -1,9 +1,9 @@
-# The tokenizer is local so the proxy can start without the backend or network.
+# The local tokenizer lets the proxy start without the backend or network.
 model: /tmp/opt-125m
 instances:
   - address: 127.0.0.1:8000
     role: aggregated
-    model: facebook/opt-125m
+# The served model name is auto-detected from the backend's /v1/models endpoint.
 port: 8868
 log_level: info
 scheduling: roundrobin

--- a/examples/aggregated/opt-125m-cpu/xpyd_aggregated.yaml
+++ b/examples/aggregated/opt-125m-cpu/xpyd_aggregated.yaml
@@ -1,12 +1,12 @@
-# The local tokenizer lets the proxy start without the backend or network.
-model: /tmp/opt-125m
+# facebook/opt-125m resolves to /tmp/tokenizers/facebook/opt-125m.
+tokenizer_path: /tmp/tokenizers
 instances:
   - address: 127.0.0.1:8000
     role: aggregated
 # The served model name is auto-detected from the backend's /v1/models endpoint.
 port: 8868
 log_level: info
-scheduling: roundrobin
+scheduling: loadbalanced
 startup:
   wait_timeout_seconds: 600
   probe_interval_seconds: 1

--- a/examples/aggregated/opt-125m-cpu/xpyd_aggregated_auto.yaml
+++ b/examples/aggregated/opt-125m-cpu/xpyd_aggregated_auto.yaml
@@ -1,0 +1,15 @@
+instances:
+  - address: 127.0.0.1:8000
+    role: aggregated
+# The served model name is auto-detected and its tokenizer is downloaded.
+port: 8868
+log_level: info
+scheduling: loadbalanced
+startup:
+  wait_timeout_seconds: 600
+  probe_interval_seconds: 1
+  heartbeat_interval_seconds: 10
+health_check:
+  enabled: true
+  interval_seconds: 1
+  timeout_seconds: 1

--- a/examples/proxy.yaml
+++ b/examples/proxy.yaml
@@ -10,7 +10,8 @@
 # ============================================================
 # Server
 # ============================================================
-model: /path/to/model           # required — path to HF model or tokenizer
+model: my-model                 # required in legacy single-model mode
+# tokenizer_path: /models/tokenizers  # optional local root; my-model/ must exist
 port: 8868                      # proxy listen port (default: 8000)
 log_level: warning              # debug | info | warning | error
 

--- a/tests/unit/test_aggregated_completion.py
+++ b/tests/unit/test_aggregated_completion.py
@@ -29,9 +29,22 @@ class TestIsAggregatedModel:
     def test_empty_aggregated_list_not_aggregated(self):
         proxy = MagicMock()
         proxy.aggregated_instances = {"qwen-2": []}
+        proxy.registry = None
         from xpyd.proxy import Proxy
 
         assert Proxy._is_aggregated_model(proxy, "qwen-2") is False
+
+    def test_auto_discovered_aggregated_model_detected(self):
+        from xpyd.proxy import Proxy
+
+        registry = InstanceRegistry()
+        registry.add("aggregated", "10.0.0.1:8000")
+        registry.update_model("10.0.0.1:8000", "qwen-2")
+        proxy = MagicMock()
+        proxy.aggregated_instances = {"": ["10.0.0.1:8000"]}
+        proxy.registry = registry
+
+        assert Proxy._is_aggregated_model(proxy, "qwen-2") is True
 
 
 class TestScheduleAggregated:
@@ -68,6 +81,26 @@ class TestScheduleAggregated:
 
         result = Proxy.schedule_aggregated(proxy, "nonexistent")
         assert result is None
+
+    def test_schedule_auto_discovered_aggregated_model(self):
+        from xpyd.proxy import Proxy
+        from xpyd.scheduler import RoundRobinSchedulingPolicy
+
+        reg = InstanceRegistry()
+        reg.add("aggregated", "10.0.0.3:8000")
+        reg.update_model("10.0.0.3:8000", "qwen-2")
+        reg.mark_healthy("10.0.0.3:8000")
+        proxy = MagicMock()
+        proxy.aggregated_instances = {"": ["10.0.0.3:8000"]}
+        proxy.registry = reg
+        proxy.scheduling_policy = RoundRobinSchedulingPolicy(registry=reg)
+        proxy.model_schedulers = {}
+        proxy._aggregated_rr_counters = {}
+        proxy._aggregated_instances_for_model = (
+            lambda model: Proxy._aggregated_instances_for_model(proxy, model)
+        )
+
+        assert Proxy.schedule_aggregated(proxy, "qwen-2") == "10.0.0.3:8000"
 
 
 class TestScheduleAggregatedCompletion:

--- a/tests/unit/test_completion_handler.py
+++ b/tests/unit/test_completion_handler.py
@@ -519,7 +519,7 @@ class TestHandleCompletion:
 
         with (
             patch("xpyd.routes.completions.track_request_start", return_value=0),
-            patch("xpyd.routes.completions.track_request_end"),
+            patch("xpyd.routes.completions.track_request_end") as track_end,
         ):
             result = await handle_completion(
                 "/v1/completions", raw_request, server, is_chat=False
@@ -527,6 +527,7 @@ class TestHandleCompletion:
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == 400
+        track_end.assert_called_once_with("/v1/completions", 0)
 
     @pytest.mark.asyncio
     async def test_missing_required_field(self, server):
@@ -535,7 +536,7 @@ class TestHandleCompletion:
 
         with (
             patch("xpyd.routes.completions.track_request_start", return_value=0),
-            patch("xpyd.routes.completions.track_request_end"),
+            patch("xpyd.routes.completions.track_request_end") as track_end,
         ):
             result = await handle_completion(
                 "/v1/completions", raw_request, server, is_chat=False
@@ -543,6 +544,7 @@ class TestHandleCompletion:
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == 400
+        track_end.assert_called_once_with("/v1/completions", 0)
 
     @pytest.mark.asyncio
     async def test_no_available_instance(self, server):
@@ -558,7 +560,7 @@ class TestHandleCompletion:
 
         with (
             patch("xpyd.routes.completions.track_request_start", return_value=0),
-            patch("xpyd.routes.completions.track_request_end"),
+            patch("xpyd.routes.completions.track_request_end") as track_end,
             patch("xpyd.routes.completions.logger"),
         ):
             result = await handle_completion(
@@ -568,6 +570,36 @@ class TestHandleCompletion:
         assert isinstance(result, JSONResponse)
         assert result.status_code == 503
         server.exception_handler.assert_called_once()
+        track_end.assert_called_once_with("/v1/completions", 0)
+
+    @pytest.mark.asyncio
+    async def test_unknown_aggregated_model_ends_metrics(self, server):
+        raw_request = AsyncMock()
+        raw_request.json = AsyncMock(
+            return_value={
+                "model": "unknown-model",
+                "prompt": "hello",
+                "max_tokens": 1,
+            }
+        )
+        raw_request.headers = {}
+        raw_request.client = None
+
+        server._is_aggregated_model.return_value = True
+        server.schedule_aggregated.return_value = None
+        server.registry.get_registered_models.return_value = ["known-model"]
+
+        with (
+            patch("xpyd.routes.completions.track_request_start", return_value=0),
+            patch("xpyd.routes.completions.track_request_end") as track_end,
+        ):
+            result = await handle_completion(
+                "/v1/completions", raw_request, server, is_chat=False
+            )
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 404
+        track_end.assert_called_once_with("/v1/completions", 0)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("source", ["decode", "prefill"])

--- a/tests/unit/test_completion_handler.py
+++ b/tests/unit/test_completion_handler.py
@@ -26,8 +26,9 @@ def server():
     """Create a mock server with minimal attributes."""
     srv = MagicMock()
     srv.get_total_token_length = MagicMock(
-        side_effect=lambda x: len(x) if isinstance(x, str) else 0
+        side_effect=lambda x, model="": len(x) if isinstance(x, str) else 0
     )
+    srv.get_tokenizer = MagicMock(side_effect=lambda model="": srv.tokenizer)
     srv._is_aggregated_model = MagicMock(return_value=False)
     return srv
 
@@ -183,7 +184,9 @@ class TestExtractPromptInfo:
     def test_completion_token_ids(self, server):
         """Flat list of ints (already tokenized) should return its length."""
         server.get_total_token_length = MagicMock(
-            side_effect=lambda x: len(x) if isinstance(x, (str, list)) else 0
+            side_effect=lambda x, model="": (
+                len(x) if isinstance(x, (str, list)) else 0
+            )
         )
         total_length, _, _ = extract_prompt_info(
             {"prompt": [101, 102, 103]},

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -110,6 +110,8 @@ class TestProxyConfigValidation:
         assert cfg.roundrobin is False
         assert cfg.admin_api_key is None
         assert cfg.openai_api_key is None
+        assert cfg.tokenizer_path is None
+        assert cfg.scheduling == "loadbalanced"
 
 
 class TestProxyConfigFromArgs:
@@ -169,6 +171,19 @@ class TestProxyConfigFromYaml:
         assert cfg.model == "my-model"
         assert cfg.decode == ["10.0.0.1:8000"]
         assert cfg.port == 8000
+
+    def test_from_yaml_tokenizer_path(self, tmp_path):
+        p = tmp_path / "cfg.yaml"
+        p.write_text(
+            "tokenizer_path: /models/tokenizers\n"
+            "instances:\n"
+            "  - address: '10.0.0.1:8000'\n"
+            "    role: aggregated\n"
+            "    model: org/model\n"
+        )
+        cfg = ProxyConfig.from_yaml(str(p))
+        assert cfg.tokenizer_path == "/models/tokenizers"
+        assert cfg.scheduling == "loadbalanced"
 
     def test_from_yaml_full(self, tmp_path):
         import textwrap

--- a/tests/unit/test_discovery_models.py
+++ b/tests/unit/test_discovery_models.py
@@ -47,6 +47,53 @@ class TestProbeModels:
         assert info.model == "llama-3"
 
     @pytest.mark.asyncio()
+    async def test_probe_models_notifies_model_callback(self, registry):
+        callback = AsyncMock()
+        discovery = NodeDiscovery(
+            prefill_instances=["10.0.0.1:8000"],
+            decode_instances=[],
+            registry=registry,
+            on_model_discovered=callback,
+        )
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={"data": [{"id": "org/model"}]}
+        )
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_resp
+
+        await discovery._probe_models(mock_session, "10.0.0.1:8000")
+
+        callback.assert_awaited_once_with("org/model")
+
+    @pytest.mark.asyncio()
+    async def test_probe_models_propagates_callback_failure(self, registry):
+        callback = AsyncMock(side_effect=ValueError("bad tokenizer path"))
+        discovery = NodeDiscovery(
+            prefill_instances=["10.0.0.1:8000"],
+            decode_instances=[],
+            registry=registry,
+            on_model_discovered=callback,
+        )
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={"data": [{"id": "org/model"}]}
+        )
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_resp
+
+        with pytest.raises(ValueError, match="bad tokenizer path"):
+            await discovery._probe_models(
+                mock_session, "10.0.0.1:8000"
+            )
+
+    @pytest.mark.asyncio()
     async def test_probe_models_non_200_graceful(self, discovery, registry):
         """_probe_models handles non-200 response gracefully without updating."""
         mock_resp = AsyncMock()

--- a/tests/unit/test_tokenizer_loading.py
+++ b/tests/unit/test_tokenizer_loading.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for per-model tokenizer loading and scheduler fallback."""
+
+import itertools
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from xpyd.proxy import Proxy
+from xpyd.registry import InstanceRegistry
+from xpyd.scheduler import RoundRobinSchedulingPolicy
+
+
+def _proxy(tokenizer_path=None):
+    proxy = Proxy.__new__(Proxy)
+    proxy.tokenizer_path = tokenizer_path
+    proxy._tokenizers = {}
+    proxy._round_robin_models = set()
+    proxy.tokenizer = None
+    return proxy
+
+
+def test_local_tokenizer_uses_model_named_subdirectory(tmp_path):
+    model_dir = tmp_path / "org" / "model"
+    model_dir.mkdir(parents=True)
+    tokenizer = MagicMock()
+    proxy = _proxy(str(tmp_path))
+
+    with patch(
+        "xpyd.proxy.AutoTokenizer.from_pretrained",
+        return_value=tokenizer,
+    ) as load:
+        assert proxy.ensure_tokenizer("org/model") is True
+
+    load.assert_called_once_with(
+        str(model_dir),
+        local_files_only=True,
+    )
+    assert proxy.get_tokenizer("org/model") is tokenizer
+
+
+def test_local_tokenizer_missing_directory_has_guidance(tmp_path):
+    proxy = _proxy(str(tmp_path))
+
+    with pytest.raises(
+        ValueError,
+        match=r"Expected directory: .*org/model.*Set tokenizer_path",
+    ):
+        proxy.ensure_tokenizer("org/model")
+
+
+def test_local_tokenizer_invalid_files_have_guidance(tmp_path):
+    model_dir = tmp_path / "org" / "model"
+    model_dir.mkdir(parents=True)
+    proxy = _proxy(str(tmp_path))
+
+    with (
+        patch(
+            "xpyd.proxy.AutoTokenizer.from_pretrained",
+            side_effect=OSError("missing tokenizer_config.json"),
+        ),
+        pytest.raises(
+            ValueError,
+            match="model-named subdirectory with valid Hugging Face",
+        ),
+    ):
+        proxy.ensure_tokenizer("org/model")
+
+
+def test_remote_tokenizer_success_keeps_default_scheduler():
+    tokenizer = MagicMock()
+    proxy = _proxy()
+
+    with patch(
+        "xpyd.proxy.AutoTokenizer.from_pretrained",
+        return_value=tokenizer,
+    ) as load:
+        assert proxy.ensure_tokenizer("org/model") is True
+
+    load.assert_called_once_with("org/model", local_files_only=False)
+    assert proxy.uses_round_robin_fallback("org/model") is False
+
+
+def test_remote_tokenizer_failure_falls_back_to_round_robin():
+    proxy = _proxy()
+
+    with (
+        patch(
+            "xpyd.proxy.AutoTokenizer.from_pretrained",
+            side_effect=OSError("offline"),
+        ),
+        patch("xpyd.proxy.logger.warning") as warning,
+    ):
+        assert proxy.ensure_tokenizer("org/model") is False
+
+    assert proxy.uses_round_robin_fallback("org/model") is True
+    assert "Falling back to roundrobin" in warning.call_args.args[0]
+
+
+def test_pd_model_with_failed_tokenizer_uses_round_robin():
+    registry = InstanceRegistry()
+    registry.add("prefill", "10.0.0.1:8000", model="org/model")
+    registry.add("decode", "10.0.0.2:8000", model="org/model")
+    registry.mark_healthy("10.0.0.1:8000")
+    registry.mark_healthy("10.0.0.2:8000")
+    proxy = _proxy()
+    proxy.registry = registry
+    proxy._round_robin_models.add("org/model")
+    proxy._round_robin_policy = RoundRobinSchedulingPolicy(
+        registry=registry
+    )
+    proxy.scheduling_policy = MagicMock()
+
+    selected = Proxy.schedule(
+        proxy,
+        itertools.cycle(["10.0.0.1:8000"]),
+        is_prompt=True,
+        request_len=0,
+        max_tokens=1,
+        model="org/model",
+    )
+    Proxy.schedule_completion(
+        proxy,
+        prefill_instance=selected,
+        req_len=0,
+    )
+
+    assert selected == "10.0.0.1:8000"
+    proxy.scheduling_policy.schedule.assert_not_called()
+    proxy.scheduling_policy.schedule_completion.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_backend_tokenizer_used_when_local_tokenizer_unavailable():
+    registry = InstanceRegistry()
+    registry.add("prefill", "10.0.0.1:8000", model="org/model")
+    registry.mark_healthy("10.0.0.1:8000")
+    proxy = _proxy()
+    proxy.registry = registry
+    proxy.prefill_instances = ["10.0.0.1:8000"]
+
+    response = MagicMock(status=200)
+    response.json = AsyncMock(return_value={"tokens": [1, 2, 3]})
+    request_context = MagicMock()
+    request_context.__aenter__ = AsyncMock(return_value=response)
+    request_context.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.post.return_value = request_context
+    session_context = MagicMock()
+    session_context.__aenter__ = AsyncMock(return_value=session)
+    session_context.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "xpyd.proxy.aiohttp.ClientSession",
+        return_value=session_context,
+    ):
+        tokens = await Proxy.tokenize_on_backend(
+            proxy,
+            {
+                "model": "org/model",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+            is_chat=True,
+        )
+
+    assert tokens == [1, 2, 3]
+    session.post.assert_called_once_with(
+        "http://10.0.0.1:8000/tokenize",
+        json={
+            "model": "org/model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "add_generation_prompt": True,
+        },
+    )

--- a/xpyd/config.py
+++ b/xpyd/config.py
@@ -140,6 +140,7 @@ class ProxyConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     model: str = ""
+    tokenizer_path: Optional[str] = None
     prefill: List[str] = []
     decode: List[str] = []
     instances: Optional[List[InstanceEntry]] = None
@@ -426,6 +427,7 @@ class ProxyConfig(BaseModel):
         # Argparse defaults — used to detect whether user explicitly set a value.
         _arg_defaults: Dict[str, Any] = {
             "model": None,
+            "tokenizer_path": None,
             "prefill": None,
             "decode": None,
             "port": 8000,

--- a/xpyd/discovery.py
+++ b/xpyd/discovery.py
@@ -9,9 +9,10 @@ prefill and one decode node are ready.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import time
-from typing import TYPE_CHECKING, List, Optional, Set
+from typing import TYPE_CHECKING, Awaitable, Callable, List, Optional, Set
 
 import aiohttp
 
@@ -43,6 +44,9 @@ class NodeDiscovery:
         heartbeat_interval: float = 30.0,
         registry: Optional["InstanceRegistry"] = None,
         aggregated_instances: Optional[List[str]] = None,
+        on_model_discovered: Optional[
+            Callable[[str], Awaitable[None] | None]
+        ] = None,
     ):
         self.prefill_instances = prefill_instances
         self.decode_instances = decode_instances
@@ -51,6 +55,7 @@ class NodeDiscovery:
         self.wait_timeout = wait_timeout
         self.heartbeat_interval = heartbeat_interval
         self.registry = registry
+        self.on_model_discovered = on_model_discovered
 
         self.healthy_prefill: Set[str] = set()
         self.healthy_decode: Set[str] = set()
@@ -77,7 +82,7 @@ class NodeDiscovery:
         if task.cancelled():
             return
         exc = task.exception()
-        if isinstance(exc, DiscoveryTimeout):
+        if exc is not None:
             logger.critical("Discovery failed: %s", exc)
             loop = asyncio.get_event_loop()
             loop.stop()
@@ -241,6 +246,7 @@ class NodeDiscovery:
                 return  # model already set — no need to probe
         except KeyError:
             return  # instance not in registry
+        detected_model = ""
         try:
             models_url = f"http://{instance}/v1/models"
             async with session.get(models_url) as resp:
@@ -251,11 +257,7 @@ class NodeDiscovery:
                         model_name = models_data[0].get("id", "")
                         if model_name:
                             self.registry.update_model(instance, model_name)
-                            logger.info(
-                                "Auto-detected model %r on %s",
-                                model_name,
-                                instance,
-                            )
+                            detected_model = model_name
                         else:
                             logger.debug(
                                 "Empty model id from /v1/models on %s",
@@ -273,4 +275,15 @@ class NodeDiscovery:
         except Exception:
             logger.debug(
                 "Failed to probe /v1/models on %s", instance
+            )
+            return
+        if detected_model:
+            if self.on_model_discovered is not None:
+                result = self.on_model_discovered(detected_model)
+                if inspect.isawaitable(result):
+                    await result
+            logger.info(
+                "Auto-detected model %r on %s",
+                detected_model,
+                instance,
             )

--- a/xpyd/init_config.py
+++ b/xpyd/init_config.py
@@ -12,6 +12,11 @@ _TEMPLATE = """\
 # Required: model name served by this proxy
 model: "my-model"
 
+# Optional: local tokenizer root. Model "org/name" is loaded from
+# "<tokenizer_path>/org/name/". Without this setting, xPyD downloads the
+# tokenizer and falls back to roundrobin if the download fails.
+# tokenizer_path: "/models/tokenizers"
+
 # Required: at least one decode instance
 # Can be a flat list or topology dict
 decode:

--- a/xpyd/proxy.py
+++ b/xpyd/proxy.py
@@ -193,7 +193,19 @@ class Proxy:
 
     def _is_aggregated_model(self, model: str) -> bool:
         """Check if all instances for a model are aggregated-role."""
-        return model in self.aggregated_instances and len(self.aggregated_instances[model]) > 0
+        return bool(Proxy._aggregated_instances_for_model(self, model))
+
+    def _aggregated_instances_for_model(self, model: str) -> list[str]:
+        """Return configured aggregated instances, including discovered models."""
+        if self.registry is not None:
+            discovered = [
+                info.address
+                for info in self.registry.get_all_instances()
+                if info.role == "aggregated" and info.model == model
+            ]
+            if discovered:
+                return discovered
+        return list(self.aggregated_instances.get(model, []))
 
     def schedule_aggregated(self, model: str, **kwargs) -> Optional[str]:
         """Schedule a aggregated instance for the given model.
@@ -204,9 +216,7 @@ class Proxy:
         Supports load-balanced, round-robin, consistent-hash, power-of-two,
         and cache-aware selection.
         """
-        if model not in self.aggregated_instances:
-            return None
-        instances = self.aggregated_instances[model]
+        instances = Proxy._aggregated_instances_for_model(self, model)
         if not instances:
             return None
 

--- a/xpyd/proxy.py
+++ b/xpyd/proxy.py
@@ -12,12 +12,14 @@ The decode node's response is returned to the client (streaming or
 non-streaming).
 """
 import argparse
+import asyncio
 import itertools
 import json
 import logging
 import os
 import sys
 from collections.abc import AsyncGenerator
+from pathlib import Path
 from typing import Any, Callable, Optional, cast
 
 import aiohttp
@@ -162,6 +164,7 @@ class Proxy:
                  registry: Optional[InstanceRegistry] = None,
                  aggregated_instances: Optional[dict[str, list[str]]] = None,
                  model_schedulers: Optional[dict[str, str]] = None,
+                 tokenizer_path: Optional[str] = None,
                  disaggregated_mode: str = "direct",
                  zmq_config=None):
         self.prefill_instances = prefill_instances
@@ -173,6 +176,12 @@ class Proxy:
         self.registry = registry
         self.aggregated_instances = aggregated_instances or {}
         self.model_schedulers = model_schedulers or {}
+        self.tokenizer_path = tokenizer_path
+        self._tokenizers: dict[str, Any] = {}
+        self._round_robin_models: set[str] = set()
+        self._round_robin_policy = RoundRobinSchedulingPolicy(
+            registry=registry
+        )
         self.disaggregated_mode = disaggregated_mode
         self.first_token_source = first_token_source
         self.zmq_config = zmq_config
@@ -189,7 +198,74 @@ class Proxy:
             else D_first_token_generator
         )
         self.d_first_token_generator_class = D_first_token_generator
-        self.tokenizer = AutoTokenizer.from_pretrained(model)
+        self.tokenizer = None
+
+    def ensure_tokenizer(self, model: str) -> bool:
+        """Load a model tokenizer or mark the model for round-robin fallback."""
+        if not model or model in self._tokenizers:
+            return bool(model and model in self._tokenizers)
+        if model in self._round_robin_models:
+            return False
+
+        source = model
+        local_only = False
+        if self.tokenizer_path:
+            root = Path(self.tokenizer_path).expanduser().resolve()
+            source_path = root.joinpath(*model.split("/")).resolve()
+            try:
+                source_path.relative_to(root)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid model name {model!r}: tokenizer directory must "
+                    f"remain under tokenizer_path {str(root)!r}."
+                ) from exc
+            if not source_path.is_dir():
+                raise ValueError(
+                    f"Tokenizer for model {model!r} was not found. Expected "
+                    f"directory: {source_path}. Set tokenizer_path to the "
+                    "parent directory whose model-named subdirectories "
+                    "contain Hugging Face tokenizer files."
+                )
+            source = str(source_path)
+            local_only = True
+
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(
+                source,
+                local_files_only=local_only,
+            )
+        except Exception as exc:
+            if self.tokenizer_path:
+                raise ValueError(
+                    f"Failed to load tokenizer for model {model!r} from "
+                    f"{source!r}: {exc}. Verify that tokenizer_path contains "
+                    "a model-named subdirectory with valid Hugging Face "
+                    "tokenizer files."
+                ) from exc
+            self._round_robin_models.add(model)
+            logger.warning(
+                "Unable to download tokenizer for model %r: %s. "
+                "Falling back to roundrobin scheduling for this model.",
+                model,
+                exc,
+            )
+            return False
+
+        self._tokenizers[model] = tokenizer
+        if self.tokenizer is None:
+            self.tokenizer = tokenizer
+        logger.info("Loaded tokenizer for model %r from %s", model, source)
+        return True
+
+    def get_tokenizer(self, model: str = ""):
+        """Return the tokenizer loaded for a model, if available."""
+        if model:
+            return self.__dict__.get("_tokenizers", {}).get(model)
+        return self.__dict__.get("tokenizer")
+
+    def uses_round_robin_fallback(self, model: str) -> bool:
+        """Return whether tokenizer loading forced round-robin for a model."""
+        return model in self.__dict__.get("_round_robin_models", set())
 
     def _is_aggregated_model(self, model: str) -> bool:
         """Check if all instances for a model are aggregated-role."""
@@ -230,7 +306,11 @@ class Proxy:
 
         # Determine scheduler strategy for this model
         # Fallback chain: model-level → global policy type → load_balanced
-        strategy = self.model_schedulers.get(model, "")
+        strategy = (
+            "roundrobin"
+            if Proxy.uses_round_robin_fallback(self, model)
+            else self.model_schedulers.get(model, "")
+        )
         strategy = {
             "load_balanced": "loadbalanced",
             "round_robin": "roundrobin",
@@ -319,7 +399,7 @@ class Proxy:
             "registry": self.registry,
         }
         if strategy == "cache_aware":
-            options["tokenizer"] = self.tokenizer
+            options["tokenizer"] = Proxy.get_tokenizer(self, model)
         policy = default_registry.create(strategy, **options)
         self._aggregated_policies[model] = policy
         return policy
@@ -427,7 +507,12 @@ class Proxy:
                  max_tokens: Optional[int] = None,
                  **kwargs) -> Optional[str]:
         model = kwargs.pop("model", "")
-        return self.scheduling_policy.schedule(
+        policy = (
+            self._round_robin_policy
+            if Proxy.uses_round_robin_fallback(self, model)
+            else self.scheduling_policy
+        )
+        return policy.schedule(
             cycler, is_prompt, request_len, max_tokens, model=model, **kwargs,
         )
 
@@ -435,16 +520,108 @@ class Proxy:
                             prefill_instance: Optional[str] = None,
                             decode_instance: Optional[str] = None,
                             req_len: Optional[int] = None) -> None:
+        instances = [
+            instance
+            for instance in (prefill_instance, decode_instance)
+            if instance
+        ]
+        if (
+            self.registry is not None
+            and instances
+            and all(
+                Proxy.uses_round_robin_fallback(
+                    self,
+                    self.registry.get_instance_info(instance).model
+                )
+                for instance in instances
+            )
+        ):
+            return
         self.scheduling_policy.schedule_completion(
             prefill_instance=prefill_instance,
             decode_instance=decode_instance,
             req_len=req_len)
 
-    def get_total_token_length(self, prompt: Any) -> int:
+    def get_total_token_length(self, prompt: Any, model: str = "") -> int:
         """Compute total token length — delegates to :func:`xpyd.utils.get_total_token_length`."""
         from xpyd.utils import get_total_token_length as _get_total_token_length
 
-        return _get_total_token_length(self.tokenizer, prompt)
+        tokenizer = Proxy.get_tokenizer(self, model)
+        if tokenizer is None:
+            return 0
+        return _get_total_token_length(tokenizer, prompt)
+
+    async def tokenize_on_backend(
+        self,
+        request: dict,
+        is_chat: bool,
+    ) -> list[int]:
+        """Tokenize through a healthy prefill node when no local tokenizer exists."""
+        model = request.get("model", "")
+        instances = (
+            self.registry.get_available_instances("prefill", model=model)
+            if self.registry is not None
+            else self.prefill_instances
+        )
+        if not instances:
+            raise HTTPException(
+                status_code=503,
+                detail=f"No prefill instance can tokenize model {model!r}",
+            )
+
+        if is_chat:
+            allowed = {
+                "model",
+                "messages",
+                "add_generation_prompt",
+                "continue_final_message",
+                "chat_template",
+                "chat_template_kwargs",
+                "tools",
+            }
+            payload = {
+                key: value
+                for key, value in request.items()
+                if key in allowed
+            }
+            continue_final_message = request.get(
+                "continue_final_message", False
+            )
+            payload["add_generation_prompt"] = request.get(
+                "add_generation_prompt", not continue_final_message
+            )
+        else:
+            prompt = request.get("prompt")
+            if isinstance(prompt, list):
+                return list(prompt)
+            payload = {"model": model, "prompt": prompt}
+
+        url = f"http://{instances[0]}/tokenize"
+        try:
+            async with aiohttp.ClientSession(
+                timeout=AIOHTTP_TIMEOUT
+            ) as session, session.post(url, json=payload) as response:
+                data = await response.json()
+                if response.status != 200:
+                    raise HTTPException(
+                        status_code=502,
+                        detail=(
+                            f"Backend tokenizer returned HTTP "
+                            f"{response.status}: {data}"
+                        ),
+                    )
+        except aiohttp.ClientError as exc:
+            raise HTTPException(
+                status_code=502,
+                detail=f"Failed to tokenize through {url}: {exc}",
+            ) from exc
+        tokens = data.get("tokens")
+        if not isinstance(tokens, list):
+            raise HTTPException(
+                status_code=502,
+                detail=f"Backend tokenizer at {url} returned no tokens",
+            )
+        return tokens
 
     def exception_handler(self, prefill_instance: Optional[str] = None, decode_instance: Optional[str] = None, req_len: Optional[int] = None) -> None:
         if prefill_instance or decode_instance:
@@ -777,9 +954,15 @@ class ProxyServer:
             registry=self.registry,
             aggregated_instances=aggregated_instances,
             model_schedulers=model_scheduler_config,
+            tokenizer_path=config.tokenizer_path,
             disaggregated_mode=config.disaggregated_mode,
             zmq_config=config.zmq,
         )
+        configured_models = self.registry.get_registered_models()
+        if not configured_models and config.model:
+            configured_models = [config.model]
+        for model_name in configured_models:
+            self.proxy_instance.ensure_tokenizer(model_name)
 
     def verify_model_config(self, instances: list, model: str) -> None:
         for instance in instances:
@@ -806,6 +989,9 @@ class ProxyServer:
             heartbeat_interval=self.config.heartbeat_interval_seconds,
             registry=self.registry,
             aggregated_instances=self._all_aggregated,
+            on_model_discovered=lambda model: asyncio.to_thread(
+                self.proxy_instance.ensure_tokenizer, model
+            ),
         )
 
         app = FastAPI()

--- a/xpyd/routes/completions.py
+++ b/xpyd/routes/completions.py
@@ -67,6 +67,7 @@ def validate_completion_request(request: dict, is_chat: bool) -> JSONResponse | 
 
 def extract_prompt_info(request: dict, is_chat: bool, server: Proxy) -> tuple[int, int, str]:
     """Extract prompt metrics. Returns (total_length, max_tokens, prompt_text)."""
+    model = request.get("model", "")
     if is_chat:
         total_length = 0
         prompt_parts = []
@@ -75,13 +76,13 @@ def extract_prompt_info(request: dict, is_chat: bool, server: Proxy) -> tuple[in
             if content is None:
                 continue
             if isinstance(content, str):
-                total_length += server.get_total_token_length(content)
+                total_length += server.get_total_token_length(content, model)
                 prompt_parts.append(content)
             elif isinstance(content, list):
                 for part in content:
                     if isinstance(part, dict) and part.get("type") == "text":
                         text = part.get("text", "")
-                        total_length += server.get_total_token_length(text)
+                        total_length += server.get_total_token_length(text, model)
                         prompt_parts.append(text)
         max_tokens = request.get("max_completion_tokens", 0)
         if max_tokens == 0:
@@ -89,7 +90,7 @@ def extract_prompt_info(request: dict, is_chat: bool, server: Proxy) -> tuple[in
         prompt_text = " ".join(prompt_parts)
     else:
         prompt = request.get("prompt")
-        total_length = server.get_total_token_length(prompt)
+        total_length = server.get_total_token_length(prompt, model)
         max_tokens = request.get("max_tokens", 0)
         prompt_text = prompt if isinstance(prompt, str) else str(prompt)
     return total_length, max_tokens, prompt_text
@@ -152,12 +153,18 @@ def build_zmq_prepare_request(
 
 def tokenize_zmq_prompt(request: dict, is_chat: bool, server: Proxy) -> list[int]:
     """Tokenize the exact prompt used by the LMCache sender and receiver."""
+    tokenizer = server.get_tokenizer(request.get("model", ""))
+    if tokenizer is None:
+        raise ValueError(
+            "ZMQ prompt tokenization requires a tokenizer for model "
+            f"{request.get('model', '')!r}"
+        )
     if not is_chat:
         prompt = request["prompt"]
         return (
             list(prompt)
             if isinstance(prompt, list)
-            else server.tokenizer.encode(prompt)
+            else tokenizer.encode(prompt)
         )
 
     template_kwargs = dict(request.get("chat_template_kwargs") or {})
@@ -172,7 +179,7 @@ def tokenize_zmq_prompt(request: dict, is_chat: bool, server: Proxy) -> list[int
         template_kwargs["chat_template"] = request["chat_template"]
     if request.get("tools") is not None:
         template_kwargs["tools"] = request["tools"]
-    tokenized = server.tokenizer.apply_chat_template(
+    tokenized = tokenizer.apply_chat_template(
         request["messages"], **template_kwargs
     )
     if isinstance(tokenized, Mapping):
@@ -538,7 +545,14 @@ async def handle_completion(endpoint: str, raw_request: Request, server: Proxy, 
             )
         zmq_prompt_tokens = None
         if server.disaggregated_mode == "zmq":
-            zmq_prompt_tokens = tokenize_zmq_prompt(request, is_chat, server)
+            if server.get_tokenizer(requested_model) is None:
+                zmq_prompt_tokens = await server.tokenize_on_backend(
+                    request, is_chat
+                )
+            else:
+                zmq_prompt_tokens = tokenize_zmq_prompt(
+                    request, is_chat, server
+                )
             total_length = len(zmq_prompt_tokens)
         kv_prepare_request = build_kv_prepare_request(
             request, is_chat, server.disaggregated_mode,

--- a/xpyd/routes/completions.py
+++ b/xpyd/routes/completions.py
@@ -499,10 +499,12 @@ async def handle_completion(endpoint: str, raw_request: Request, server: Proxy, 
         try:
             request = await raw_request.json()
         except (json.JSONDecodeError, ValueError):
+            track_request_end(endpoint, _metrics_start)
             return error_response("Invalid JSON in request body", INVALID_REQUEST, 400)
 
         error_resp = validate_completion_request(request, is_chat)
         if error_resp:
+            track_request_end(endpoint, _metrics_start)
             return error_resp
 
         prefill_instance = None
@@ -586,6 +588,7 @@ async def handle_completion(endpoint: str, raw_request: Request, server: Proxy, 
                 "No available instance",
                 extra={"endpoint": endpoint, "prompt_length": total_length, "model": requested_model},
             )
+            track_request_end(endpoint, _metrics_start)
             # Check for unknown model first to return a clean 404 without
             # triggering error-path side effects (logging, metrics, etc.)
             if requested_model and server.registry is not None:
@@ -952,6 +955,7 @@ async def _handle_aggregated_completion(
     )
 
     if instance is None:
+        track_request_end(endpoint, metrics_start)
         # Check for unknown model
         if model and server.registry is not None:
             known_models = server.registry.get_registered_models()


### PR DESCRIPTION
## Summary

- route requests using model names auto-discovered from backend `/v1/models`
- add strict model-to-tokenizer resolution under optional `tokenizer_path` (for example, `facebook/opt-125m` resolves to `<tokenizer_path>/facebook/opt-125m`)
- automatically load remote tokenizers when no local root is configured; retain load balancing on success and warn plus fall back per model to round-robin on failure
- support tokenizer-less P/D fallback, including backend `/tokenize` for ZMQ requests that require exact token IDs
- keep `loadbalanced` as the default scheduler and apply fallback consistently to Aggregated and P/D topologies
- cover completion, chat completion, SSE streaming, health, models, metrics, invalid requests, tokenizer loading, and fallback behavior with stronger assertions
- close the metrics lifecycle for rejected requests so `proxy_active_requests` does not leak

## Validation

- `python -m pytest tests/unit/ -q --tb=short --timeout=120` (454 passed)
- `ruff check .`
- `isort --check-only --diff --skip xpyd .`
- CPU example lifecycle passed with real vLLM CPU and OPT-125M, including proxy-first startup, discovery, inference APIs, node loss, and reconnection
- external integration tests passed

CPU run: https://github.com/xPyD-hub/xPyD-proxy/actions/runs/31927781149